### PR TITLE
feat: ssl-manager integration, HAProxy support, and IPFS traffic optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ logs/
 *.key
 *.crt
 *.csr
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
 # IPFS Storage Service with WSS Support
-# Debian-based with IPFS Kubo, nginx (TLS termination), and supervisord
+# Based on ssl-manager for automatic SSL certificate management and HAProxy integration
 
-FROM debian:bookworm-slim
+FROM ghcr.io/unicitynetwork/ssl-manager:latest
 
-# Install dependencies (including Python for nostr-pinner)
+# ssl-manager is based on debian:trixie-slim and already includes:
+#   certbot, openssl, curl, jq, netcat-openbsd, python3, procps, ca-certificates
+#
+# IPFS-specific dependencies:
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    curl \
-    ca-certificates \
+    tini \
     nginx \
     libnginx-mod-stream \
     supervisor \
     gettext-base \
-    openssl \
-    procps \
-    python3 \
     python3-pip \
     python3-dev \
     # Build dependencies for secp256k1 Python package
@@ -61,8 +59,10 @@ COPY config/nginx.conf.template /etc/nginx/nginx.conf.template
 COPY scripts/ /usr/local/bin/
 RUN chmod 755 /usr/local/bin/*.sh
 
-# Volumes
-VOLUME /data/ipfs
+# Volumes — declared for documentation; explicit -v mounts are always used
+# Do NOT use VOLUME ["/data/ipfs"] — it creates anonymous volumes that silently
+# mask mount failures, risking data loss of 690GB+ of pinned IPFS content.
+VOLUME ["/etc/letsencrypt"]
 
 # Ports
 # 4001 - IPFS Swarm (TCP/UDP)
@@ -72,19 +72,17 @@ VOLUME /data/ipfs
 # 8080 - IPFS Gateway (internal)
 # 443  - HTTPS Gateway (via nginx)
 # 9080 - HTTP Gateway (exposed)
+# Port 80 is already EXPOSE'd by ssl-manager base image
 EXPOSE 4001/tcp 4001/udp 4003 443 9080
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD /usr/local/bin/healthcheck.sh
 
 # Environment variables
 ENV DOMAIN=localhost \
-    SSL_CERT_PATH=/etc/ssl/certs/fullchain.pem \
-    SSL_KEY_PATH=/etc/ssl/private/privkey.pem \
     IPFS_PROFILE=server \
     IPFS_LOGGING=info \
-    DEV_MODE=false \
     # Nostr pinner configuration (Unicity relays)
     NOSTR_RELAYS="wss://nostr-relay.testnet.unicity.network,ws://unicity-nostr-relay-20250927-alb-1919039002.me-central-1.elb.amazonaws.com:8080" \
     IPFS_API_URL="http://127.0.0.1:5001" \
@@ -101,4 +99,4 @@ ENV DOMAIN=localhost \
     ANNOUNCE_INTERVAL="0" \
     ANNOUNCE_PROBABILITY="0.000277778"
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -1,6 +1,8 @@
 # nginx configuration for IPFS WSS proxy and HTTPS gateway
 # Template variables: ${DOMAIN}, ${SSL_CERT_PATH}, ${SSL_KEY_PATH}
 
+user www-data www-data;
+
 # Load stream module for WSS proxy
 load_module /usr/lib/nginx/modules/ngx_stream_module.so;
 
@@ -79,7 +81,8 @@ http {
 
     # HTTPS Gateway server
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name ${DOMAIN};
 
         ssl_certificate ${SSL_CERT_PATH};
@@ -111,10 +114,9 @@ http {
             proxy_cache_lock on;
             add_header X-Cache-Status $upstream_cache_status;
 
-            # CRITICAL: Force application/json to prevent Kubo returning DAG-JSON format
-            # Without this, Accept: */* causes Kubo to return UnixFS DAG node structure
-            # instead of the actual file content for dag-pb CIDs
-            proxy_set_header Accept "application/json";
+            # NOTE: Do not override Accept header - Kubo 0.39+ runs in trustless mode
+            # by default (Gateway.DeserializedResponses=null) and rejects non-trustless
+            # Accept values like application/json with 406. Let the client set Accept.
 
             # Prevent cache poisoning (keep for defense in depth)
             proxy_set_header Accept-Encoding "";
@@ -187,6 +189,18 @@ http {
 
         # API endpoints - CORS handled by Kubo API natively
         # Pass through Kubo's CORS headers to avoid duplicates
+
+        # Version endpoint for connectivity checks (read-only, safe)
+        location /api/v0/version {
+            proxy_pass http://127.0.0.1:5001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 10s;
+            proxy_pass_header Access-Control-Allow-Origin;
+            proxy_pass_header Access-Control-Allow-Methods;
+            proxy_pass_header Access-Control-Allow-Headers;
+            proxy_pass_header Access-Control-Expose-Headers;
+        }
 
         # Safe API proxy for content preloading (refs triggers fetch via bitswap)
         location /api/v0/refs {
@@ -330,10 +344,26 @@ http {
         }
     }
 
-    # HTTP redirect to HTTPS (optional, disabled by default)
-    # server {
-    #     listen 80;
-    #     server_name ${DOMAIN};
-    #     return 301 https://$server_name$request_uri;
-    # }
+    # HTTP gateway on port 9080 (no SSL, for direct access or ssl-manager proxy)
+    server {
+        listen 9080;
+        server_name _;
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location / {
+            proxy_pass http://ipfs_gateway;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            client_max_body_size 100M;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+        }
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 # IPFS Storage Service (Single Container with Nostr Pinner)
-# Usage:
-#   SSL_CERT=/path/to/fullchain.pem SSL_KEY=/path/to/privkey.pem DOMAIN=example.com docker-compose up -d
+#
+# For production with HAProxy + auto SSL, use run-ipfs.sh instead:
+#   ./run-ipfs.sh --domain ipfs.example.com --ssl-email admin@example.com
+#
+# This docker-compose.yml is for development/testing without HAProxy:
+#   docker-compose up -d
 
 services:
   # Main IPFS container with nginx WSS proxy and integrated nostr-pinner
@@ -9,24 +13,33 @@ services:
     image: ipfs-storage:latest
     container_name: ipfs-kubo
     restart: always
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     volumes:
       - ipfs-data:/data/ipfs
-      # SSL certificates - must be provided via environment variables
-      - ${SSL_CERT:?SSL_CERT is required}:/etc/ssl/certs/fullchain.pem:ro
-      - ${SSL_KEY:?SSL_KEY is required}:/etc/ssl/private/privkey.pem:ro
+      - letsencrypt-data:/etc/letsencrypt
       # Optional: Initial pin list (only needed on first run, pins persist in volume)
       - ${PIN_LIST:-/dev/null}:/data/pin-list.txt:ro
     ports:
       - "${PORT_SWARM:-4001}:4001/tcp"      # Swarm TCP
       - "${PORT_SWARM:-4001}:4001/udp"      # Swarm UDP/QUIC
       - "${PORT_WSS:-4003}:4003"            # WSS (TLS-terminated)
-      - "${PORT_HTTPS:-443}:443"            # HTTPS Gateway (set empty to disable)
-      - "${PORT_HTTP:-9080}:8080"           # HTTP Gateway
+      - "${PORT_HTTPS:-443}:443"            # HTTPS Gateway
+      - "${PORT_HTTP:-9080}:9080"           # HTTP Gateway (via ssl-manager proxy)
+      - "80:80"                             # HTTP (ACME challenges + ssl-manager proxy)
       # Note: 5001 (API) is NOT exposed externally for security
     environment:
+      # SSL configuration (ssl-manager)
+      - SSL_DOMAIN=${SSL_DOMAIN:-}
+      - SSL_ADMIN_EMAIL=${SSL_ADMIN_EMAIL:-}
+      - SSL_REQUIRED=${SSL_REQUIRED:-false}
+      - SSL_TEST_MODE=${SSL_TEST_MODE:-true}
+      - SSL_HTTPS_PORT=${SSL_HTTPS_PORT:-443}
+      - APP_HTTP_PORT=${APP_HTTP_PORT:-9080}
       # IPFS configuration
-      - DOMAIN=${DOMAIN:?DOMAIN is required}
-      - DEV_MODE=${DEV_MODE:-false}
+      - DOMAIN=${DOMAIN:-localhost}
       - IPFS_PROFILE=${IPFS_PROFILE:-server}
       - IPFS_LOGGING=${IPFS_LOGGING:-info}
       # Nostr pinner configuration (integrated, Unicity relays)
@@ -43,7 +56,7 @@ services:
       - NOSTR_PRIVATE_KEY=${NOSTR_PRIVATE_KEY:-}
       - ANNOUNCE_INTERVAL=${ANNOUNCE_INTERVAL:-0}
       - ANNOUNCE_PROBABILITY=${ANNOUNCE_PROBABILITY:-0.000277778}
-      # IPNS staleness and chain validation configuration (critical bug fixes)
+      # IPNS staleness and chain validation configuration
       - STALE_THRESHOLD_SECONDS=${STALE_THRESHOLD_SECONDS:-15}
       - CHAIN_VALIDATION_MODE=${CHAIN_VALIDATION_MODE:-strict}
       - CID_FETCH_TIMEOUT=${CID_FETCH_TIMEOUT:-3}
@@ -57,10 +70,10 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 120s
 
 volumes:
   ipfs-data:
     name: ipfs-data
-    # Use external: true if you have an existing volume
-    # external: true
+  letsencrypt-data:
+    name: letsencrypt-data

--- a/run-ipfs.sh
+++ b/run-ipfs.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#
+# IPFS Storage Docker Runner
+#
+# Starts the IPFS Kubo node in Docker with optional SSL/TLS
+# via the ssl-manager base image and HAProxy auto-registration.
+#
+# Usage:
+#   ./run-ipfs.sh                                      # No SSL (self-signed, direct ports)
+#   ./run-ipfs.sh --domain ipfs.example.com             # SSL with HAProxy
+#   ./run-ipfs.sh --domain ipfs.example.com --no-haproxy  # SSL with direct ports
+#   ./run-ipfs.sh --domain ipfs.example.com --ssl-email admin@example.com
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── App identity (set BEFORE sourcing run-lib.sh) ────────────────────────────
+CONTAINER_NAME="${CONTAINER_NAME:-ipfs-kubo}"
+IMAGE_NAME="${IPFS_IMAGE:-ipfs-storage:latest}"
+APP_TITLE="IPFS Storage Service"
+
+# ─── App networking ───────────────────────────────────────────────────────────
+APP_NET="${APP_NET:-ipfs-net}"
+# run-lib.sh mounts DATA_VOLUME at /data; we use a scratch volume for that
+# and mount the real IPFS data at /data/ipfs via app_docker_args()
+IPFS_DATA_VOLUME="${IPFS_DATA_VOLUME:-ipfs-data}"
+DATA_VOLUME="${DATA_VOLUME:-ipfs-scratch}"
+HEALTH_PORT=5001                       # IPFS API — first port to come up
+SSL_CHECK_PORT=443                     # HTTPS gateway — verify after SSL setup
+SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+APP_HTTP_PORT="${APP_HTTP_PORT:-9080}"  # HTTP gateway exposed via ssl-manager proxy
+
+# ─── App defaults ─────────────────────────────────────────────────────────────
+DOMAIN="${DOMAIN:-localhost}"
+PORT_SWARM="${PORT_SWARM:-4001}"
+PORT_WSS="${PORT_WSS:-4003}"
+PORT_HTTPS="${PORT_HTTPS:-443}"
+PORT_HTTP="${PORT_HTTP:-9080}"
+
+# Nostr pinner configuration
+NOSTR_RELAYS="${NOSTR_RELAYS:-wss://nostr-relay.testnet.unicity.network,ws://unicity-nostr-relay-20250927-alb-1919039002.me-central-1.elb.amazonaws.com:8080}"
+NOSTR_PRIVATE_KEY="${NOSTR_PRIVATE_KEY:-}"
+
+# Sidecar configuration
+STALE_THRESHOLD_SECONDS="${STALE_THRESHOLD_SECONDS:-15}"
+CHAIN_VALIDATION_MODE="${CHAIN_VALIDATION_MODE:-strict}"
+
+# Pin list (optional, only needed on first run)
+PIN_LIST="${PIN_LIST:-}"
+
+# ─── Source the ssl-manager run library ───────────────────────────────────────
+if [ ! -f "${SCRIPT_DIR}/run-lib.sh" ]; then
+    echo "ERROR: run-lib.sh not found in ${SCRIPT_DIR}" >&2
+    echo "Download it from https://github.com/unicitynetwork/ssl-manager" >&2
+    exit 1
+fi
+source "${SCRIPT_DIR}/run-lib.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# App-specific hooks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+app_parse_args() {
+    case "$1" in
+        --port-swarm)           require_arg "$1" "${2:-}"; PORT_SWARM="$2";  return 2 ;;
+        --port-wss)             require_arg "$1" "${2:-}"; PORT_WSS="$2";    return 2 ;;
+        --port-http)            require_arg "$1" "${2:-}"; PORT_HTTP="$2";   return 2 ;;
+        --nostr-relays)         require_arg "$1" "${2:-}"; NOSTR_RELAYS="$2"; return 2 ;;
+        --nostr-private-key)    require_arg "$1" "${2:-}"; NOSTR_PRIVATE_KEY="$2"; return 2 ;;
+        --pin-list)             require_arg "$1" "${2:-}"; PIN_LIST="$2";    return 2 ;;
+        --stale-threshold)      require_arg "$1" "${2:-}"; STALE_THRESHOLD_SECONDS="$2"; return 2 ;;
+        --chain-validation)     require_arg "$1" "${2:-}"; CHAIN_VALIDATION_MODE="$2"; return 2 ;;
+        *)                      return 0 ;;
+    esac
+}
+
+app_validate() {
+    validate_port "PORT_SWARM" "$PORT_SWARM"
+    validate_port "PORT_WSS" "$PORT_WSS"
+    validate_port "PORT_HTTP" "$PORT_HTTP"
+}
+
+app_env_args() {
+    echo "-e DOMAIN=${SSL_DOMAIN:-$DOMAIN}"
+    echo "-e IPFS_PROFILE=server"
+    echo "-e NOSTR_RELAYS=$NOSTR_RELAYS"
+    echo "-e STALE_THRESHOLD_SECONDS=$STALE_THRESHOLD_SECONDS"
+    echo "-e CHAIN_VALIDATION_MODE=$CHAIN_VALIDATION_MODE"
+    if [ -n "$NOSTR_PRIVATE_KEY" ]; then echo "-e NOSTR_PRIVATE_KEY=$NOSTR_PRIVATE_KEY"; fi
+}
+
+app_port_args() {
+    echo "-p ${PORT_SWARM}:4001/tcp"
+    echo "-p ${PORT_SWARM}:4001/udp"
+    echo "-p ${PORT_WSS}:4003"
+    echo "-p ${PORT_HTTPS}:443"
+    echo "-p ${PORT_HTTP}:9080"
+}
+
+app_docker_args() {
+    # Each flag on its own line — _read_docker_args splits on first space per line
+    echo "-v ${IPFS_DATA_VOLUME}:/data/ipfs"
+
+    # Mount pin list if provided
+    if [ -n "$PIN_LIST" ] && [ -f "$PIN_LIST" ]; then
+        echo "-v $(realpath "$PIN_LIST"):/data/pin-list.txt:ro"
+    fi
+
+    # Ulimits for IPFS connection handling
+    echo "--ulimit nofile=65536:65536"
+
+    # Auto-populate HAProxy extra ports for IPFS protocols
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ] && [ -z "$EXTRA_PORTS" ]; then
+        EXTRA_PORTS='[{"listen":4001,"target":4001,"mode":"tcp"},{"listen":4003,"target":4003,"mode":"tcp"},{"listen":9080,"target":9080,"mode":"http"}]'
+        echo "-e EXTRA_PORTS=$EXTRA_PORTS"
+    fi
+}
+
+app_print_config() {
+    echo "  Nostr:      ${NOSTR_RELAYS%%,*}..."
+    if [ -n "$PIN_LIST" ]; then echo "  Pin list:   $PIN_LIST"; fi
+}
+
+app_help() {
+    cat <<'APPHELP'
+IPFS Configuration:
+  --port-swarm <port>        Swarm TCP/UDP port (default: 4001)
+  --port-wss <port>          WSS port (default: 4003)
+  --port-http <port>         HTTP gateway port (default: 9080)
+  --pin-list <file>          Initial pin list file (CIDs, one per line)
+
+Nostr Pinner:
+  --nostr-relays <urls>      Comma-separated Nostr relay URLs
+  --nostr-private-key <key>  Nostr private key for announcements
+
+Sidecar:
+  --stale-threshold <secs>   IPNS staleness threshold (default: 15)
+  --chain-validation <mode>  Chain validation mode: strict|log_only (default: strict)
+APPHELP
+}
+
+app_health_check() {
+    local container="$1"
+
+    # 1. IPFS daemon responding
+    local peer_id
+    peer_id=$(docker exec "$container" curl -sf -X POST http://127.0.0.1:5001/api/v0/id 2>/dev/null | jq -r '.ID' 2>/dev/null)
+    if [ -n "$peer_id" ] && [ "$peer_id" != "null" ]; then
+        echo "pass:IPFS daemon: ${peer_id:0:16}..."
+    else
+        echo "fail:IPFS API not responding"
+    fi
+
+    # 2. nginx running
+    if docker exec "$container" pgrep -x nginx >/dev/null 2>&1; then
+        echo "pass:nginx running"
+    else
+        echo "fail:nginx not running"
+    fi
+
+    # 3. Swarm peers
+    local peers
+    peers=$(docker exec "$container" curl -sf -X POST http://127.0.0.1:5001/api/v0/swarm/peers 2>/dev/null | jq '.Peers | length' 2>/dev/null)
+    if [ -n "$peers" ] && [ "$peers" != "null" ] && [ "$peers" -gt 0 ] 2>/dev/null; then
+        echo "pass:Swarm peers: $peers connected"
+    else
+        echo "warn:No swarm peers yet (may still be connecting)"
+    fi
+
+    # 4. Nostr pinner running
+    if docker exec "$container" pgrep -f nostr_pinner >/dev/null 2>&1; then
+        echo "pass:Nostr pinner running"
+    else
+        echo "warn:Nostr pinner not running"
+    fi
+}
+
+app_summary() {
+    echo ""
+    echo "Endpoints:"
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ] && [ -n "$SSL_DOMAIN" ]; then
+        echo "  Gateway:   https://$SSL_DOMAIN/ipfs/<CID>"
+        echo "  WSS:       /dns4/$SSL_DOMAIN/tcp/4003/wss"
+        echo "  Swarm:     $SSL_DOMAIN:4001 (via HAProxy)"
+        echo "  HTTP:      $SSL_DOMAIN:9080 (via HAProxy)"
+    else
+        echo "  Gateway:   https://localhost:$PORT_HTTPS/ipfs/<CID>"
+        echo "  WSS:       /dns4/${SSL_DOMAIN:-localhost}/tcp/$PORT_WSS/wss"
+        echo "  Swarm:     localhost:$PORT_SWARM"
+        echo "  HTTP:      localhost:$PORT_HTTP"
+    fi
+    echo ""
+    echo "  Pins:  docker exec \"$CONTAINER_NAME\" ipfs pin ls --type=recursive"
+    echo "  Peers: docker exec \"$CONTAINER_NAME\" ipfs swarm peers"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Run
+# ═══════════════════════════════════════════════════════════════════════════════
+ssl_manager_run "$@"

--- a/run-lib.sh
+++ b/run-lib.sh
@@ -1,0 +1,441 @@
+#!/bin/bash
+#
+# ssl-manager run library — source this into your app-specific run script.
+#
+# Provides the common startup pattern for any Docker service using the
+# ssl-manager base image:
+#
+#   1. Parse SSL/HAProxy CLI arguments
+#   2. Create Docker networks
+#   3. Start the container (docker create + network connect + start)
+#   4. Wait for readiness (port polling)
+#   5. Run health checks (color-coded: green/yellow/red)
+#   6. Call app-specific functional checks
+#
+# ─── Usage in your run script: ────────────────────────────────────────────────
+#
+#   #!/bin/bash
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+#   # App identity (set BEFORE sourcing)
+#   CONTAINER_NAME="${CONTAINER_NAME:-my-service}"
+#   IMAGE_NAME="${MY_IMAGE:-my-service:latest}"
+#   APP_TITLE="My Service Runner"
+#
+#   # App networking
+#   APP_NET="${APP_NET:-my-app-net}"       # app-specific Docker network
+#   DATA_VOLUME="${DATA_VOLUME:-my-data}"  # app data volume
+#   HEALTH_PORT=3000                       # primary port to poll for readiness
+#   SSL_CHECK_PORT=3443                    # SSL port to verify (optional)
+#   SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-3443}"
+#   APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+#
+#   # Source the library
+#   source "${SCRIPT_DIR}/run-lib.sh"
+#
+#   # ── App-specific hooks (all optional) ──
+#
+#   app_parse_args() {                     # custom CLI args
+#       case "$1" in
+#           --db-host) require_arg "$1" "${2:-}"; DB_HOST="$2"; return 2 ;;
+#           *) return 0 ;;
+#       esac
+#   }
+#
+#   app_env_args() {                       # extra -e flags for docker create
+#       echo "-e DB_HOST=${DB_HOST:-localhost}"
+#   }
+#
+#   app_port_args() {                      # extra -p flags (direct mode only)
+#       echo "-p 3000:3000"
+#   }
+#
+#   app_docker_args() {                    # extra docker create flags
+#       echo "--dns 8.8.8.8"
+#   }
+#
+#   app_health_check() {                   # functional checks (after ports up)
+#       local container="$1"
+#       # Each line: "pass:message", "warn:message", or "fail:message"
+#       local resp
+#       resp=$(docker exec "$container" curl -sf localhost:3000/health 2>/dev/null)
+#       if [ -n "$resp" ]; then
+#           echo "pass:Health endpoint OK"
+#       else
+#           echo "fail:Health endpoint not responding"
+#       fi
+#   }
+#
+#   app_validate() { ... }                 # custom validation after arg parsing
+#   app_print_config() { ... }             # print app config section
+#   app_help() { ... }                     # print app-specific help section
+#   app_summary() { ... }                  # print app endpoints after startup
+#   app_needs_host_gateway() { return 0; } # return 0 if --add-host needed
+#
+#   # ── Run ──
+#   ssl_manager_run "$@"
+#
+
+set -euo pipefail
+
+# ─── Colors ───────────────────────────────────────────────────────────────────
+C_GREEN='\033[0;32m'
+C_YELLOW='\033[0;33m'
+C_RED='\033[0;31m'
+C_BOLD='\033[1m'
+C_RESET='\033[0m'
+
+WARN_COUNT=0
+FAIL_COUNT=0
+
+check_pass() { printf "  ${C_GREEN}✓${C_RESET} %s\n" "$1"; }
+check_warn() { printf "  ${C_YELLOW}⚠${C_RESET} %s\n" "$1"; WARN_COUNT=$((WARN_COUNT + 1)); }
+check_fail() { printf "  ${C_RED}✗${C_RESET} %s\n" "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+require_arg() {
+    if [[ $# -lt 2 || "$2" == --* ]]; then
+        printf 'ERROR: %s requires a value\n' "$1" >&2
+        exit 1
+    fi
+}
+
+validate_port() {
+    local name="$1" value="$2"
+    if [ "$value" = "0" ]; then return 0; fi
+    if ! [[ "$value" =~ ^[0-9]+$ ]] || [ "$value" -lt 1 ] || [ "$value" -gt 65535 ]; then
+        printf 'ERROR: %s must be a port (1-65535), got: %s\n' "$name" "$value" >&2
+        exit 1
+    fi
+}
+
+# ─── SSL / HAProxy defaults (override BEFORE sourcing) ────────────────────────
+: "${SSL_DOMAIN:=}"
+: "${SSL_ADMIN_EMAIL:=}"
+: "${SSL_REQUIRED:=true}"
+: "${SSL_STAGING:=}"
+: "${SSL_TEST_MODE:=}"
+: "${SSL_HTTPS_PORT:=443}"
+: "${APP_HTTP_PORT:=0}"
+: "${EXTRA_PORTS:=}"
+: "${HAPROXY_HOST:=haproxy}"
+: "${HAPROXY_API_PORT:=8404}"
+: "${HAPROXY_NET:=haproxy-net}"
+: "${HAPROXY_API_KEY:=}"
+: "${LETSENCRYPT_VOLUME:=letsencrypt-data}"
+: "${HEALTH_TIMEOUT:=120}"
+: "${HEALTH_PORT:=80}"
+
+USE_HAPROXY=true
+SHOW_HELP=false
+
+# ─── Parse one SSL/HAProxy CLI argument ───────────────────────────────────────
+_ssl_parse_arg() {
+    case "$1" in
+        --domain)         require_arg "$1" "${2:-}"; SSL_DOMAIN="$2";       return 2 ;;
+        --ssl-email)      require_arg "$1" "${2:-}"; SSL_ADMIN_EMAIL="$2";  return 2 ;;
+        --ssl-staging)    SSL_STAGING="true";     return 1 ;;
+        --ssl-test-mode)  SSL_TEST_MODE="true";   return 1 ;;
+        --ssl-required)   require_arg "$1" "${2:-}"; SSL_REQUIRED="$2";     return 2 ;;
+        --no-ssl)         SSL_DOMAIN="";          return 1 ;;
+        --ssl-https-port) require_arg "$1" "${2:-}"; SSL_HTTPS_PORT="$2";   return 2 ;;
+        --app-http-port)  require_arg "$1" "${2:-}"; APP_HTTP_PORT="$2";    return 2 ;;
+        --extra-ports)    require_arg "$1" "${2:-}"; EXTRA_PORTS="$2";      return 2 ;;
+        --haproxy-host)   require_arg "$1" "${2:-}"; HAPROXY_HOST="$2";     return 2 ;;
+        --haproxy-net)    require_arg "$1" "${2:-}"; HAPROXY_NET="$2";      return 2 ;;
+        --haproxy-api-key) require_arg "$1" "${2:-}"; HAPROXY_API_KEY="$2"; return 2 ;;
+        --no-haproxy)     USE_HAPROXY=false; HAPROXY_HOST=""; return 1 ;;
+        --container-name) require_arg "$1" "${2:-}"; CONTAINER_NAME="$2";   return 2 ;;
+        --image)          require_arg "$1" "${2:-}"; IMAGE_NAME="$2";       return 2 ;;
+        --help|-h)        SHOW_HELP=true; return 1 ;;
+        *)                return 0 ;;
+    esac
+}
+
+# ─── Build env args for docker create ─────────────────────────────────────────
+_ssl_env_args() {
+    if [ -n "$SSL_DOMAIN" ]; then
+        echo "-e SSL_DOMAIN=$SSL_DOMAIN"
+        echo "-e SSL_REQUIRED=$SSL_REQUIRED"
+        echo "-e SSL_HTTPS_PORT=$SSL_HTTPS_PORT"
+        echo "-e APP_HTTP_PORT=$APP_HTTP_PORT"
+        [ -n "$SSL_ADMIN_EMAIL" ] && echo "-e SSL_ADMIN_EMAIL=$SSL_ADMIN_EMAIL"
+        [ -n "$SSL_STAGING" ]     && echo "-e SSL_STAGING=$SSL_STAGING"
+        [ -n "$SSL_TEST_MODE" ]   && echo "-e SSL_TEST_MODE=$SSL_TEST_MODE"
+    fi
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
+        echo "-e HAPROXY_HOST=$HAPROXY_HOST"
+        echo "-e HAPROXY_API_PORT=$HAPROXY_API_PORT"
+        [ -n "$HAPROXY_API_KEY" ] && echo "-e HAPROXY_API_KEY=$HAPROXY_API_KEY"
+        [ -n "$EXTRA_PORTS" ]     && echo "-e EXTRA_PORTS=$EXTRA_PORTS"
+    fi
+}
+
+# ─── Build port args ──────────────────────────────────────────────────────────
+_ssl_port_args() {
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
+        return  # HAProxy owns all ports
+    fi
+    [ -n "$SSL_DOMAIN" ] && echo "-p 80:80"
+}
+
+# ─── Setup Docker networks ───────────────────────────────────────────────────
+_ssl_setup_networks() {
+    [ -n "${APP_NET:-}" ] && { docker network inspect "$APP_NET" >/dev/null 2>&1 || docker network create "$APP_NET"; }
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
+        docker network inspect "$HAPROXY_NET" >/dev/null 2>&1 || docker network create "$HAPROXY_NET"
+    fi
+}
+
+# ─── Stop existing container ─────────────────────────────────────────────────
+_ssl_stop_existing() {
+    if [ -n "$(docker ps -aq --filter "name=^${CONTAINER_NAME}$" 2>/dev/null)" ]; then
+        echo "Stopping existing container '$CONTAINER_NAME'..."
+        docker stop "$CONTAINER_NAME" 2>/dev/null || true
+        docker rm "$CONTAINER_NAME" 2>/dev/null || true
+    fi
+}
+
+# ─── Start container (create + network connect + start) ───────────────────────
+_ssl_start_container() {
+    local primary_net="${APP_NET:-default}"
+    local secondary_net=""
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
+        primary_net="$HAPROXY_NET"
+        secondary_net="${APP_NET:-}"
+    fi
+
+    local all_env=() all_ports=() all_extra=() host_opts=()
+
+    # Helper: read lines of "-flag value" or "-flag=value" and split into
+    # separate array elements so docker receives them as distinct arguments.
+    # e.g., "-e SSL_DOMAIN=foo" → array gets two elements: "-e" "SSL_DOMAIN=foo"
+    _read_docker_args() {
+        local -n _arr=$1; shift
+        while IFS= read -r _line; do
+            [ -z "$_line" ] && continue
+            # Split "-flag value" into two elements
+            if [[ "$_line" == -* && "$_line" == *" "* ]]; then
+                _arr+=("${_line%% *}" "${_line#* }")
+            else
+                _arr+=("$_line")
+            fi
+        done < <("$@")
+    }
+
+    _read_docker_args all_env _ssl_env_args
+    _read_docker_args all_ports _ssl_port_args
+
+    if type app_env_args &>/dev/null; then
+        _read_docker_args all_env app_env_args
+    fi
+    if type app_port_args &>/dev/null; then
+        if ! { [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; }; then
+            _read_docker_args all_ports app_port_args
+        fi
+    fi
+    if type app_docker_args &>/dev/null; then
+        _read_docker_args all_extra app_docker_args
+    fi
+    if type app_needs_host_gateway &>/dev/null && app_needs_host_gateway; then
+        [[ "${OSTYPE:-linux}" != "darwin"* ]] && host_opts=(--add-host=host.docker.internal:host-gateway)
+    fi
+
+    docker create \
+        --name "$CONTAINER_NAME" \
+        --restart on-failure:5 \
+        --network "$primary_net" \
+        "${host_opts[@]}" \
+        -v "${DATA_VOLUME}:/data" \
+        -v "${LETSENCRYPT_VOLUME}:/etc/letsencrypt" \
+        "${all_ports[@]}" \
+        "${all_env[@]}" \
+        "${all_extra[@]}" \
+        "$IMAGE_NAME" >/dev/null
+
+    [ -n "$secondary_net" ] && docker network connect "$secondary_net" "$CONTAINER_NAME"
+
+    if ! docker start "$CONTAINER_NAME" >/dev/null; then
+        echo "ERROR: Failed to start container" >&2; exit 1
+    fi
+}
+
+# ─── Wait for a TCP port ─────────────────────────────────────────────────────
+_ssl_wait_for_port() {
+    local container="$1" port="$2" label="$3" timeout="$4"
+    local elapsed=0
+    while [ "$elapsed" -lt "$timeout" ]; do
+        if ! docker ps -q --filter "name=^${container}$" 2>/dev/null | grep -q .; then
+            printf "\n"; check_fail "Container exited unexpectedly"
+            docker logs "$container" 2>&1 | tail -15 >&2; return 1
+        fi
+        if docker exec "$container" nc -z localhost "$port" 2>/dev/null; then
+            printf "\r\033[K"; return 0
+        fi
+        printf "\r  %s... (%ds)" "$label" "$elapsed"
+        sleep 2; elapsed=$((elapsed + 2))
+    done
+    printf "\n"; return 1
+}
+
+# ─── SSL certificate check ───────────────────────────────────────────────────
+_ssl_check_cert() {
+    local container="$1" domain="$2"
+    local cert_info
+    cert_info=$(docker exec "$container" openssl x509 -enddate -noout \
+        -in "/etc/letsencrypt/live/${domain}/fullchain.pem" 2>/dev/null | sed 's/notAfter=//')
+    if [ -n "$cert_info" ]; then
+        local cert_epoch now_epoch days_left
+        cert_epoch=$(date -d "$cert_info" +%s 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        days_left=$(( (cert_epoch - now_epoch) / 86400 ))
+        if [ "$days_left" -gt 14 ] 2>/dev/null; then
+            check_pass "SSL cert expires: $cert_info ($days_left days)"
+        elif [ "$days_left" -gt 0 ] 2>/dev/null; then
+            check_warn "SSL cert expires: $cert_info ($days_left days — renew soon!)"
+        else
+            check_fail "SSL cert expired: $cert_info"
+        fi
+    else
+        check_warn "Could not read SSL certificate"
+    fi
+}
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+_ssl_print_help() {
+    cat <<'HELP'
+SSL Configuration:
+  --domain <domain>        Domain for automatic SSL (certbot)
+  --ssl-email <email>      Email for Let's Encrypt registration
+  --ssl-staging            Use Let's Encrypt staging (test certs)
+  --ssl-test-mode          Self-signed cert for dev/CI
+  --ssl-required <bool>    Fail if SSL setup fails (default: true)
+  --ssl-https-port <port>  Backend port for HTTPS via HAProxy
+  --app-http-port <port>   App HTTP port behind ssl-manager proxy
+  --extra-ports <json>     Extra HAProxy port mappings (JSON array)
+  --no-ssl                 Disable SSL entirely
+
+HAProxy Configuration:
+  --haproxy-host <host>    HAProxy hostname (default: haproxy)
+  --haproxy-net <network>  HAProxy Docker network (default: haproxy-net)
+  --haproxy-api-key <key>  Bearer token for Registration API
+  --no-haproxy             Skip HAProxy, expose ports directly
+
+Container:
+  --container-name <name>  Container name
+  --image <image>          Docker image
+  --help, -h               Show this help
+HELP
+    type app_help &>/dev/null && { echo ""; app_help; }
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main entry point — call from your app script: ssl_manager_run "$@"
+# ═══════════════════════════════════════════════════════════════════════════════
+ssl_manager_run() {
+    # Parse arguments
+    local consumed=0
+    while [[ $# -gt 0 ]]; do
+        # Capture return code without triggering set -e.
+        # Functions return N>0 to indicate "consumed N args", 0 for "not mine".
+        # set -e treats non-zero return as error, so we use "if" to suppress it.
+        if _ssl_parse_arg "$@"; then consumed=0; else consumed=$?; fi
+        if [ "$consumed" -gt 0 ]; then shift "$consumed"; continue; fi
+        if type app_parse_args &>/dev/null; then
+            if app_parse_args "$@"; then consumed=0; else consumed=$?; fi
+            if [ "$consumed" -gt 0 ]; then shift "$consumed"; continue; fi
+        fi
+        echo "Unknown option: $1" >&2
+        echo "Run with --help for usage." >&2
+        exit 1
+    done
+    [ "$SHOW_HELP" = true ] && { echo "Usage: $(basename "$0") [options]"; echo ""; _ssl_print_help; exit 0; }
+
+    # Validate
+    validate_port "SSL_HTTPS_PORT" "$SSL_HTTPS_PORT"
+    validate_port "APP_HTTP_PORT" "$APP_HTTP_PORT"
+    [ "$APP_HTTP_PORT" = "80" ] && { echo "ERROR: APP_HTTP_PORT cannot be 80" >&2; exit 1; }
+    if [ -n "$SSL_DOMAIN" ] && ! printf '%s' "$SSL_DOMAIN" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$'; then
+        printf 'ERROR: Invalid domain: %s\n' "$SSL_DOMAIN" >&2; exit 1
+    fi
+    type app_validate &>/dev/null && app_validate
+
+    # Print config
+    printf "\n${C_BOLD}%s${C_RESET}\n" "${APP_TITLE:-Docker Service}"
+    echo "════════════════════════════════════════"
+    echo "  Image:      $IMAGE_NAME"
+    echo "  Container:  $CONTAINER_NAME"
+    [ -n "$SSL_DOMAIN" ] && echo "  SSL Domain: $SSL_DOMAIN" || echo "  SSL:        disabled"
+    [ -n "$SSL_DOMAIN" ] && [ -n "$SSL_ADMIN_EMAIL" ] && echo "  SSL Email:  $SSL_ADMIN_EMAIL"
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
+        echo "  HAProxy:    $HAPROXY_HOST (via $HAPROXY_NET)"
+    else
+        echo "  HAProxy:    disabled (direct ports)"
+    fi
+    type app_print_config &>/dev/null && app_print_config
+    echo ""
+
+    # Setup
+    _ssl_setup_networks
+    _ssl_stop_existing
+    _ssl_start_container
+
+    # Wait for readiness
+    echo "Waiting for service to start..."
+    if ! _ssl_wait_for_port "$CONTAINER_NAME" "$HEALTH_PORT" "Starting up" "$HEALTH_TIMEOUT"; then
+        printf "${C_RED}Service did not start within ${HEALTH_TIMEOUT}s${C_RESET}\n"
+        echo "  Logs: docker logs -f $CONTAINER_NAME"; exit 1
+    fi
+    if [ -n "$SSL_DOMAIN" ] && [ -n "${SSL_CHECK_PORT:-}" ]; then
+        _ssl_wait_for_port "$CONTAINER_NAME" "$SSL_CHECK_PORT" "SSL setup" "$HEALTH_TIMEOUT" || \
+            check_warn "SSL port $SSL_CHECK_PORT not ready within timeout"
+    fi
+
+    # Health & functional checks
+    echo ""
+    echo "Health & Functional Checks"
+    echo "────────────────────────────────────────"
+    check_pass "Container running"
+    check_pass "Port $HEALTH_PORT listening"
+    if [ -n "$SSL_DOMAIN" ] && [ -n "${SSL_CHECK_PORT:-}" ]; then
+        if docker exec "$CONTAINER_NAME" nc -z localhost "$SSL_CHECK_PORT" 2>/dev/null; then
+            check_pass "SSL port $SSL_CHECK_PORT listening"
+        else
+            check_fail "SSL port $SSL_CHECK_PORT not listening"
+        fi
+        _ssl_check_cert "$CONTAINER_NAME" "$SSL_DOMAIN"
+    fi
+
+    # App-specific functional checks
+    if type app_health_check &>/dev/null; then
+        while IFS= read -r result; do
+            [ -z "$result" ] && continue
+            local level="${result%%:*}" msg="${result#*:}"
+            case "$level" in
+                pass) check_pass "$msg" ;; warn) check_warn "$msg" ;;
+                fail) check_fail "$msg" ;; *)    check_pass "$result" ;;
+            esac
+        done < <(app_health_check "$CONTAINER_NAME")
+    fi
+
+    # Summary line
+    echo "────────────────────────────────────────"
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        printf "${C_RED}RESULT: %d check(s) failed, %d warning(s)${C_RESET}\n" "$FAIL_COUNT" "$WARN_COUNT"
+    elif [ "$WARN_COUNT" -gt 0 ]; then
+        printf "${C_YELLOW}RESULT: All critical checks passed, %d warning(s)${C_RESET}\n" "$WARN_COUNT"
+    else
+        printf "${C_GREEN}RESULT: All checks passed${C_RESET}\n"
+    fi
+
+    # Commands
+    echo ""
+    echo "Service started: $CONTAINER_NAME"
+    echo ""
+    echo "Commands:"
+    echo "  Logs:    docker logs -f \"$CONTAINER_NAME\""
+    echo "  Stop:    docker stop \"$CONTAINER_NAME\""
+    [ -n "$SSL_DOMAIN" ] && echo "  SSL:     docker exec \"$CONTAINER_NAME\" certbot certificates"
+    type app_summary &>/dev/null && app_summary
+    echo ""
+}

--- a/scripts/configure-ipfs.sh
+++ b/scripts/configure-ipfs.sh
@@ -42,13 +42,26 @@ su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config Addresses.API /ip4/
 # Bind Gateway to all interfaces (within container)
 su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config Addresses.Gateway /ip4/0.0.0.0/tcp/8080"
 
-# Enable relay for browser clients
+# Enable relay client and service with resource caps
 su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.RelayClient.Enabled true"
-su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.RelayService.Enabled true"
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.RelayService '{
+  \"Enabled\": true,
+  \"ConnectionDurationLimit\": \"2m0s\",
+  \"ConnectionDataLimit\": 131072,
+  \"ReservationTTL\": \"60m\",
+  \"MaxReservations\": 64,
+  \"MaxCircuits\": 16,
+  \"BufferSize\": 4096,
+  \"MaxReservationsPerIP\": 8,
+  \"MaxReservationsPerASN\": 32
+}'"
 
-# Set connection limits for server profile
-su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.LowWater 100"
-su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.HighWater 400"
+# Connection manager: cap connections with graceful trimming
+# LowWater/HighWater ratio kept gentle (75%) to avoid connection storm churn
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.Type '\"basic\"'"
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.LowWater 96"
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.HighWater 128"
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ConnMgr.GracePeriod '\"2m\"'"
 
 # Add Unicity bootstrap peers
 echo "[IPFS] Adding Unicity bootstrap peers..."
@@ -57,14 +70,44 @@ su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD bootstrap add /dns4/unicit
 su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD bootstrap add /dns4/unicity-ipfs3.dyndns.org/tcp/4001/p2p/12D3KooWQ4aujVE4ShLjdusNZBdffq3TbzrwT2DuWZY9H1Gxhwn6" || true
 su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD bootstrap add /dns4/unicity-ipfs3.dyndns.org/tcp/4003/wss/p2p/12D3KooWQ4aujVE4ShLjdusNZBdffq3TbzrwT2DuWZY9H1Gxhwn6" || true
 
+# === RESOURCE MANAGER: cap system-wide resources ===
+# Kubo 0.19+ removed Swarm.ResourceMgr.Limits — use libp2p-resource-limit-overrides.json instead
+echo "[IPFS] Configuring resource manager limits..."
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Swarm.ResourceMgr.Enabled true"
+
+cat > /data/ipfs/libp2p-resource-limit-overrides.json << 'RESLIMITS'
+{
+  "System": {
+    "Conns": 512,
+    "ConnsInbound": 256,
+    "ConnsOutbound": 256,
+    "Streams": 2048,
+    "StreamsInbound": 1024,
+    "StreamsOutbound": 1024,
+    "FD": 4096,
+    "Memory": 1610612736
+  }
+}
+RESLIMITS
+chown ipfs:ipfs /data/ipfs/libp2p-resource-limit-overrides.json
+
+# === REPROVIDER: use "roots" strategy ===
+# "roots" announces root blocks of all DAGs (not every sub-block), keeping child blocks
+# discoverable via DAG traversal while reducing DHT announcement volume vs "all"
+# Using Provide.* (Reprovider.* deprecated since Kubo 0.38)
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Provide.Strategy '\"roots\"'"
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Provide.DHT.Interval '\"22h\"'"
+
 # === PERFORMANCE OPTIMIZATIONS FOR FAST HTTP RESPONSES ===
 echo "[IPFS] Applying performance optimizations..."
 
-# Enable Accelerated DHT Client (critical for fast IPNS lookups)
-su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Routing.AcceleratedDHTClient true"
+# Disable AcceleratedDHTClient — it aggressively crawls the full routing table,
+# generating thousands of DNS lookups and connections. Standard DHT server mode
+# is sufficient for IPNS/CID propagation and serving the network.
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Routing.AcceleratedDHTClient false"
 
-# Increase IPNS cache size for faster repeated lookups
-su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Ipns.ResolveCacheSize 4096"
+# IPNS cache: 1024 balances cold-start coverage vs DHT refresh load (was 4096)
+su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Ipns.ResolveCacheSize 1024"
 
 # Enable gateway routing API exposure
 su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs $IPFS_CMD config --json Gateway.ExposeRoutingAPI true"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,140 +1,258 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 # IPFS Storage Service Entrypoint
-# Validates SSL, initializes IPFS, configures nginx, starts supervisord
+# Integrates with ssl-manager for automatic SSL certificate management
 
-echo "========================================"
-echo "  IPFS Storage Service"
-echo "  Domain: ${DOMAIN}"
-echo "========================================"
+# ---------------------------------------------------------------------------
+# Signal handler for graceful shutdown
+# ---------------------------------------------------------------------------
+SHUTDOWN_REQUESTED=0
 
-# ==========================================
-# SSL Certificate Validation
-# ==========================================
+handle_signal() {
+    local signal=$1
+    echo "[entrypoint] Received $signal signal, initiating graceful shutdown..."
+    SHUTDOWN_REQUESTED=1
 
-validate_ssl() {
-    if [[ "${DEV_MODE}" == "true" ]]; then
-        echo "[INFO] DEV_MODE=true - Skipping SSL validation"
+    # Deregister from HAProxy if we were registered
+    if [ -n "${SSL_DOMAIN:-}" ] && [ -n "${HAPROXY_HOST:-}" ]; then
+        echo "[entrypoint] Deregistering from HAProxy..."
+        haproxy-register unregister 2>/dev/null || true
+    fi
 
-        # Generate self-signed cert for development
-        if [[ ! -f "${SSL_CERT_PATH}" ]]; then
-            echo "[INFO] Generating self-signed certificate for development..."
-            mkdir -p "$(dirname "${SSL_CERT_PATH}")" "$(dirname "${SSL_KEY_PATH}")"
-            openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-                -keyout "${SSL_KEY_PATH}" \
-                -out "${SSL_CERT_PATH}" \
-                -subj "/CN=${DOMAIN}" \
-                2>/dev/null
-            echo "[INFO] Self-signed certificate generated"
+    # Stop the HTTP reverse proxy (ssl-manager)
+    if [ -f /tmp/.ssl-http-proxy.pid ]; then
+        local proxy_pid
+        proxy_pid=$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null || true)
+        if [ -n "$proxy_pid" ] && kill -0 "$proxy_pid" 2>/dev/null; then
+            kill "$proxy_pid" 2>/dev/null || true
         fi
-        return 0
     fi
 
-    echo "[INFO] Validating SSL certificates..."
-
-    if [[ ! -f "${SSL_CERT_PATH}" ]]; then
-        echo "[ERROR] SSL certificate not found: ${SSL_CERT_PATH}"
-        echo "[ERROR] Please mount Let's Encrypt certificates or set DEV_MODE=true"
-        exit 1
+    # Stop the renewal loop
+    if [ -f /tmp/.ssl-renew.pid ]; then
+        local renew_pid
+        renew_pid=$(cat /tmp/.ssl-renew.pid 2>/dev/null || true)
+        if [ -n "$renew_pid" ] && kill -0 "$renew_pid" 2>/dev/null; then
+            kill "$renew_pid" 2>/dev/null || true
+        fi
     fi
 
-    if [[ ! -f "${SSL_KEY_PATH}" ]]; then
-        echo "[ERROR] SSL private key not found: ${SSL_KEY_PATH}"
-        echo "[ERROR] Please mount Let's Encrypt certificates or set DEV_MODE=true"
-        exit 1
+    # Forward signal to supervisord (it will stop all managed processes)
+    if [ -n "$SUPERVISOR_PID" ] && kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+        echo "[entrypoint] Forwarding $signal to supervisord (PID $SUPERVISOR_PID)..."
+        kill -"$signal" "$SUPERVISOR_PID" 2>/dev/null || true
+
+        local wait_count=0
+        while kill -0 "$SUPERVISOR_PID" 2>/dev/null && [ $wait_count -lt 30 ]; do
+            sleep 1
+            wait_count=$((wait_count + 1))
+        done
+
+        if kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+            echo "[entrypoint] Supervisord did not exit gracefully, sending SIGKILL..."
+            kill -9 "$SUPERVISOR_PID" 2>/dev/null || true
+        fi
     fi
 
-    # Validate certificate matches key
-    CERT_MODULUS=$(openssl x509 -noout -modulus -in "${SSL_CERT_PATH}" 2>/dev/null | openssl md5)
-    KEY_MODULUS=$(openssl rsa -noout -modulus -in "${SSL_KEY_PATH}" 2>/dev/null | openssl md5)
-
-    if [[ "${CERT_MODULUS}" != "${KEY_MODULUS}" ]]; then
-        echo "[ERROR] SSL certificate and key do not match"
-        exit 1
-    fi
-
-    echo "[INFO] SSL certificates validated successfully"
+    echo "[entrypoint] Graceful shutdown complete"
+    exit 0
 }
 
-# ==========================================
-# IPFS Initialization
-# ==========================================
+trap 'handle_signal TERM' SIGTERM
+trap 'handle_signal INT' SIGINT
 
+# ---------------------------------------------------------------------------
+# IPFS Initialization
+# ---------------------------------------------------------------------------
 init_ipfs() {
     export IPFS_PATH=/data/ipfs
 
-    if [[ ! -f "${IPFS_PATH}/config" ]]; then
-        echo "[INFO] Initializing IPFS repository..."
+    # Ensure data directory exists with correct ownership
+    mkdir -p "${IPFS_PATH}"
+    chown ipfs:ipfs "${IPFS_PATH}"
 
-        # Initialize with server profile
-        su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs /usr/local/bin/ipfs init --profile=${IPFS_PROFILE}"
-
-        echo "[INFO] IPFS repository initialized"
-    else
-        echo "[INFO] IPFS repository already exists"
+    # Fix ownership of critical IPFS repo files (may be corrupted by root operations)
+    # Only fix specific files — chown -R on 690GB blocks/ would take minutes
+    if [ -f "${IPFS_PATH}/config" ]; then
+        chown ipfs:ipfs "${IPFS_PATH}/config" 2>/dev/null || true
+        chown ipfs:ipfs "${IPFS_PATH}/datastore_spec" 2>/dev/null || true
+        chown -R ipfs:ipfs "${IPFS_PATH}/datastore" 2>/dev/null || true
+        chown -R ipfs:ipfs "${IPFS_PATH}/keystore" 2>/dev/null || true
     fi
 
-    # Configure IPFS for WebSocket support
-    echo "[INFO] Configuring IPFS for WebSocket transport..."
+    # Remove stale locks from previous unclean shutdown (e.g., SIGKILL)
+    rm -f "${IPFS_PATH}/repo.lock" "${IPFS_PATH}/datastore/LOCK"
+
+    if [ ! -f "${IPFS_PATH}/config" ]; then
+        # Safety guard: refuse to initialize if volume contains existing IPFS data
+        # at a different path (e.g., volume mounted at /data instead of /data/ipfs)
+        if [ -f /data/config ] && [ -d /data/blocks ]; then
+            echo "[entrypoint] FATAL: IPFS repo found at /data/ but not at /data/ipfs/"
+            echo "[entrypoint] Volume appears to be mounted at /data instead of /data/ipfs"
+            echo "[entrypoint] Refusing to initialize a new repo to protect existing data"
+            echo "[entrypoint] Fix: mount the volume at /data/ipfs (e.g., -v ipfs-data:/data/ipfs)"
+            exit 1
+        fi
+
+        echo "[entrypoint] Initializing IPFS repository..."
+        su -s /bin/sh ipfs -c "IPFS_PATH=/data/ipfs /usr/local/bin/ipfs init --profile=${IPFS_PROFILE:-server}"
+        echo "[entrypoint] IPFS repository initialized"
+    else
+        echo "[entrypoint] IPFS repository already exists"
+    fi
+
+    echo "[entrypoint] Configuring IPFS..."
     /usr/local/bin/configure-ipfs.sh
 }
 
-# ==========================================
+# ---------------------------------------------------------------------------
 # nginx Configuration
-# ==========================================
-
+# ---------------------------------------------------------------------------
 configure_nginx() {
-    echo "[INFO] Rendering nginx configuration..."
+    echo "[entrypoint] Rendering nginx configuration..."
 
-    # Ensure cache directory exists at runtime (handles volume mounts)
     mkdir -p /var/cache/nginx/ipfs
     chown -R www-data:www-data /var/cache/nginx
 
-    # Use envsubst to render template
     envsubst '${DOMAIN} ${SSL_CERT_PATH} ${SSL_KEY_PATH}' \
         < /etc/nginx/nginx.conf.template \
         > /etc/nginx/nginx.conf
 
-    # Validate nginx configuration
     if ! nginx -t 2>/dev/null; then
-        echo "[ERROR] nginx configuration is invalid"
+        echo "[entrypoint] ERROR: nginx configuration is invalid"
         nginx -t
         exit 1
     fi
 
-    echo "[INFO] nginx configuration ready"
+    echo "[entrypoint] nginx configuration ready"
 }
 
-# ==========================================
-# Main
-# ==========================================
+# ===========================================================================
+# Main execution
+# ===========================================================================
 
-main() {
-    # Step 1: Validate SSL
-    validate_ssl
+echo "========================================"
+echo "  IPFS Storage Service"
+echo "  Domain: ${DOMAIN:-localhost}"
+echo "========================================"
 
-    # Step 2: Initialize IPFS
-    init_ipfs
+# Step 1: Run ssl-setup from ssl-manager base image
+echo "[entrypoint] Running ssl-setup..."
+ssl_setup_exit=0
+/usr/local/bin/ssl-setup || ssl_setup_exit=$?
 
-    # Step 3: Configure nginx
-    configure_nginx
+if [ $ssl_setup_exit -ne 0 ]; then
+    if [ "${SSL_REQUIRED:-true}" = "true" ]; then
+        echo "[entrypoint] ERROR: ssl-setup failed (exit code $ssl_setup_exit) and SSL_REQUIRED=true"
+        echo "[entrypoint] Set SSL_REQUIRED=false to allow fallback to self-signed cert."
+        exit $ssl_setup_exit
+    else
+        echo "[entrypoint] WARNING: ssl-setup failed (exit code $ssl_setup_exit) but SSL_REQUIRED=false"
+        echo "[entrypoint] Continuing with fallback SSL configuration"
+    fi
+fi
 
-    # Step 4: Display connection info
-    echo ""
-    echo "========================================"
-    echo "  Starting Services"
-    echo "========================================"
-    echo ""
-    echo "  Swarm:    /ip4/<host>/tcp/4001"
-    echo "  WSS:      /dns4/${DOMAIN}/tcp/4003/wss"
-    echo "  Gateway:  https://${DOMAIN}:443/ipfs/<CID>"
-    echo "  HTTP:     http://<host>:9080/ipfs/<CID>"
-    echo ""
-    echo "========================================"
+# Step 2: Source SSL environment and set cert paths for nginx
+if [ -f /tmp/.ssl-env ]; then
+    . /tmp/.ssl-env
+    echo "[entrypoint] SSL configured: cert=${SSL_CERT_FILE}, key=${SSL_KEY_FILE}"
 
-    # Step 5: Start supervisord
-    exec /usr/bin/supervisord -c /etc/supervisord.conf
-}
+    # Export paths for nginx template substitution
+    export SSL_CERT_PATH="${SSL_CERT_FILE}"
+    export SSL_KEY_PATH="${SSL_KEY_FILE}"
 
-main "$@"
+    if [ -f "${SSL_CERT_FILE}" ]; then
+        EXPIRY=$(openssl x509 -enddate -noout -in "${SSL_CERT_FILE}" | cut -d= -f2)
+        echo "[entrypoint] SSL certificate expires: ${EXPIRY}"
+    fi
+
+    if [ "${SSL_TEST_MODE:-}" = "true" ]; then
+        echo "[entrypoint] WARNING: SSL_TEST_MODE is active -- using self-signed certificate"
+    fi
+else
+    echo "[entrypoint] No SSL certificates from ssl-manager -- generating self-signed cert"
+    SSL_CERT_PATH="/etc/ssl/certs/fullchain.pem"
+    SSL_KEY_PATH="/etc/ssl/private/privkey.pem"
+    export SSL_CERT_PATH SSL_KEY_PATH
+
+    if [ ! -f "${SSL_CERT_PATH}" ]; then
+        mkdir -p "$(dirname "${SSL_CERT_PATH}")" "$(dirname "${SSL_KEY_PATH}")"
+        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout "${SSL_KEY_PATH}" \
+            -out "${SSL_CERT_PATH}" \
+            -subj "/CN=${DOMAIN:-localhost}" \
+            2>/dev/null
+        echo "[entrypoint] Self-signed certificate generated"
+    fi
+fi
+
+# Step 3: Set DOMAIN from SSL_DOMAIN if available
+if [ -n "${SSL_DOMAIN:-}" ]; then
+    if [ "${DOMAIN:-localhost}" != "localhost" ] && [ "${DOMAIN}" != "${SSL_DOMAIN}" ]; then
+        echo "[entrypoint] WARNING: DOMAIN=$DOMAIN differs from SSL_DOMAIN=$SSL_DOMAIN"
+        echo "[entrypoint] Using SSL_DOMAIN for nginx server_name to match HAProxy registration"
+    fi
+    export DOMAIN="${SSL_DOMAIN}"
+fi
+
+# Step 4: Initialize IPFS
+init_ipfs
+
+# Step 5: Configure nginx
+configure_nginx
+
+# Step 6: Display connection info
+echo ""
+echo "========================================"
+echo "  Starting Services"
+echo "========================================"
+echo ""
+echo "  Swarm:    /ip4/<host>/tcp/4001"
+echo "  WSS:      /dns4/${DOMAIN}/tcp/4003/wss"
+echo "  Gateway:  https://${DOMAIN}:443/ipfs/<CID>"
+echo "  HTTP:     http://<host>:9080/ipfs/<CID>"
+echo ""
+echo "========================================"
+
+# Step 7: Start supervisord with signal forwarding
+SUPERVISOR_PID=""
+/usr/bin/supervisord -c /etc/supervisord.conf &
+SUPERVISOR_PID=$!
+echo "[entrypoint] Supervisord started (PID $SUPERVISOR_PID)"
+
+# Step 8: Watch for SSL renewal restart marker and supervisord exit
+# ssl-renew touches /tmp/.ssl-renewal-restart when certs are renewed;
+# we must reload nginx to pick up the new cert.
+while true; do
+    # Check for SSL cert renewal marker
+    if [ -f /tmp/.ssl-renewal-restart ]; then
+        rm -f /tmp/.ssl-renewal-restart
+        echo "[entrypoint] SSL certificate renewed — reloading nginx"
+
+        # Re-source cert paths (in case they changed)
+        if [ -f /tmp/.ssl-env ]; then
+            . /tmp/.ssl-env
+            export SSL_CERT_PATH="${SSL_CERT_FILE}"
+            export SSL_KEY_PATH="${SSL_KEY_FILE}"
+        fi
+
+        # Re-render nginx config with new cert paths and reload
+        configure_nginx
+        supervisorctl -c /etc/supervisord.conf signal HUP nginx 2>/dev/null || \
+            nginx -s reload 2>/dev/null || true
+        echo "[entrypoint] nginx reloaded with renewed certificate"
+    fi
+
+    # Check if supervisord is still running
+    if ! kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+        wait "$SUPERVISOR_PID" 2>/dev/null || true
+        if [ $SHUTDOWN_REQUESTED -eq 0 ]; then
+            echo "[entrypoint] Supervisord exited unexpectedly"
+            exit 1
+        fi
+        break
+    fi
+
+    sleep 10
+done


### PR DESCRIPTION
## Summary

- Migrate from manual SSL cert mounting to **ssl-manager base image** for automatic Let's Encrypt certificates and HAProxy auto-registration
- Add `run-ipfs.sh` host-side runner script for production deployments behind HAProxy (replaces docker-compose for production)
- Cap IPFS network traffic to reduce DNS flooding and excessive peer connections while remaining a full DHT server, relay service, and IPFS citizen

## Changes

### ssl-manager integration
- Base image changed from `debian:bookworm-slim` to `ghcr.io/unicitynetwork/ssl-manager:latest`
- Entrypoint calls `ssl-setup` → sources `/tmp/.ssl-env` → configures nginx with cert paths
- Graceful shutdown with HAProxy deregistration
- SSL cert renewal watcher reloads nginx automatically
- `tini` as PID 1 for proper zombie process reaping

### Traffic optimization (configure-ipfs.sh)
- Disable `AcceleratedDHTClient` (primary DNS flood source)
- ConnMgr: LowWater 96, HighWater 128, GracePeriod 2m
- ResourceMgr via `libp2p-resource-limit-overrides.json`: 256 inbound, 256 outbound, 512 total conns
- RelayService: 64 reservations, 16 circuits, 8 per IP, connection duration/TTL limits
- Reprovider: `Provide.Strategy "roots"`, 22h interval (Kubo 0.38+ config keys)
- IPNS cache: 1024 (down from 4096)

### Data safety
- Safety guard refuses `ipfs init` if existing repo detected at wrong mount point
- Stale `repo.lock` and `datastore/LOCK` removed on startup
- IPFS repo file ownership fixed on startup (config, datastore, keystore)
- Removed `VOLUME ["/data/ipfs"]` from Dockerfile to prevent anonymous volume masking mount failures

### New files
- `run-ipfs.sh` — host-side runner using ssl-manager's `run-lib.sh`
- `run-lib.sh` — copy of ssl-manager run library

## Test plan

- [x] Container starts with existing 690GB IPFS volume (PeerID preserved)
- [x] SSL certificate obtained via Let's Encrypt and HAProxy registration
- [x] IPFS daemon starts with no ConnsInbound/HighWater conflict
- [x] nginx serves HTTPS gateway and WSS proxy
- [x] Safety guard blocks startup on wrong volume mount path
- [x] Stale lock files cleaned on restart
- [ ] Verify reduced DNS query rate after deployment
- [ ] Verify swarm peer count stabilizes at ~96-128