### PR TITLE
feat: GC script, alias proxy lifecycle, and run-lib.sh update

### DIFF
--- a/run-lib.sh
+++ b/run-lib.sh
@@ -117,6 +117,7 @@ validate_port() {
 : "${SSL_TEST_MODE:=}"
 : "${SSL_HTTPS_PORT:=443}"
 : "${APP_HTTP_PORT:=0}"
+: "${SSL_DOMAIN_ALIASES:=}"
 : "${EXTRA_PORTS:=}"
 : "${HAPROXY_HOST:=haproxy}"
 : "${HAPROXY_API_PORT:=8404}"
@@ -140,6 +141,7 @@ _ssl_parse_arg() {
         --no-ssl)         SSL_DOMAIN="";          return 1 ;;
         --ssl-https-port) require_arg "$1" "${2:-}"; SSL_HTTPS_PORT="$2";   return 2 ;;
         --app-http-port)  require_arg "$1" "${2:-}"; APP_HTTP_PORT="$2";    return 2 ;;
+        --domain-aliases) require_arg "$1" "${2:-}"; SSL_DOMAIN_ALIASES="$2"; return 2 ;;
         --extra-ports)    require_arg "$1" "${2:-}"; EXTRA_PORTS="$2";      return 2 ;;
         --haproxy-host)   require_arg "$1" "${2:-}"; HAPROXY_HOST="$2";     return 2 ;;
         --haproxy-net)    require_arg "$1" "${2:-}"; HAPROXY_NET="$2";      return 2 ;;
@@ -159,15 +161,19 @@ _ssl_env_args() {
         echo "-e SSL_REQUIRED=$SSL_REQUIRED"
         echo "-e SSL_HTTPS_PORT=$SSL_HTTPS_PORT"
         echo "-e APP_HTTP_PORT=$APP_HTTP_PORT"
-        [ -n "$SSL_ADMIN_EMAIL" ] && echo "-e SSL_ADMIN_EMAIL=$SSL_ADMIN_EMAIL"
-        [ -n "$SSL_STAGING" ]     && echo "-e SSL_STAGING=$SSL_STAGING"
-        [ -n "$SSL_TEST_MODE" ]   && echo "-e SSL_TEST_MODE=$SSL_TEST_MODE"
+        if [ -n "$SSL_ADMIN_EMAIL" ]; then echo "-e SSL_ADMIN_EMAIL=$SSL_ADMIN_EMAIL"; fi
+        if [ -n "$SSL_DOMAIN_ALIASES" ]; then
+            echo "-e SSL_DOMAIN_ALIASES=$SSL_DOMAIN_ALIASES"
+            echo "-e SSL_ALIAS_PROXY_PORT=${SSL_ALIAS_PROXY_PORT:-8444}"
+        fi
+        if [ -n "$SSL_STAGING" ]; then echo "-e SSL_STAGING=$SSL_STAGING"; fi
+        if [ -n "$SSL_TEST_MODE" ]; then echo "-e SSL_TEST_MODE=$SSL_TEST_MODE"; fi
     fi
     if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
         echo "-e HAPROXY_HOST=$HAPROXY_HOST"
         echo "-e HAPROXY_API_PORT=$HAPROXY_API_PORT"
-        [ -n "$HAPROXY_API_KEY" ] && echo "-e HAPROXY_API_KEY=$HAPROXY_API_KEY"
-        [ -n "$EXTRA_PORTS" ]     && echo "-e EXTRA_PORTS=$EXTRA_PORTS"
+        if [ -n "$HAPROXY_API_KEY" ]; then echo "-e HAPROXY_API_KEY=$HAPROXY_API_KEY"; fi
+        if [ -n "$EXTRA_PORTS" ]; then echo "-e EXTRA_PORTS=$EXTRA_PORTS"; fi
     fi
 }
 
@@ -176,12 +182,12 @@ _ssl_port_args() {
     if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
         return  # HAProxy owns all ports
     fi
-    [ -n "$SSL_DOMAIN" ] && echo "-p 80:80"
+    if [ -n "$SSL_DOMAIN" ]; then echo "-p 80:80"; fi
 }
 
 # ─── Setup Docker networks ───────────────────────────────────────────────────
 _ssl_setup_networks() {
-    [ -n "${APP_NET:-}" ] && { docker network inspect "$APP_NET" >/dev/null 2>&1 || docker network create "$APP_NET"; }
+    if [ -n "${APP_NET:-}" ]; then docker network inspect "$APP_NET" >/dev/null 2>&1 || docker network create "$APP_NET"; fi
     if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
         docker network inspect "$HAPROXY_NET" >/dev/null 2>&1 || docker network create "$HAPROXY_NET"
     fi
@@ -306,6 +312,7 @@ _ssl_print_help() {
     cat <<'HELP'
 SSL Configuration:
   --domain <domain>        Domain for automatic SSL (certbot)
+  --domain-aliases <csv>   Comma-separated alias domains (multi-domain SSL)
   --ssl-email <email>      Email for Let's Encrypt registration
   --ssl-staging            Use Let's Encrypt staging (test certs)
   --ssl-test-mode          Self-signed cert for dev/CI
@@ -358,6 +365,18 @@ ssl_manager_run() {
     if [ -n "$SSL_DOMAIN" ] && ! printf '%s' "$SSL_DOMAIN" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$'; then
         printf 'ERROR: Invalid domain: %s\n' "$SSL_DOMAIN" >&2; exit 1
     fi
+    if [ -n "$SSL_DOMAIN_ALIASES" ]; then
+        if [ -z "$SSL_DOMAIN" ]; then
+            printf 'ERROR: --domain-aliases requires --domain\n' >&2; exit 1
+        fi
+        IFS=',' read -ra _check_aliases <<< "$SSL_DOMAIN_ALIASES"
+        for _ca in "${_check_aliases[@]}"; do
+            _ca=$(echo "$_ca" | xargs)
+            if [ -n "$_ca" ] && ! printf '%s' "$_ca" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$'; then
+                printf 'ERROR: Invalid alias domain: %s\n' "$_ca" >&2; exit 1
+            fi
+        done
+    fi
     type app_validate &>/dev/null && app_validate
 
     # Print config
@@ -366,6 +385,7 @@ ssl_manager_run() {
     echo "  Image:      $IMAGE_NAME"
     echo "  Container:  $CONTAINER_NAME"
     [ -n "$SSL_DOMAIN" ] && echo "  SSL Domain: $SSL_DOMAIN" || echo "  SSL:        disabled"
+    if [ -n "$SSL_DOMAIN_ALIASES" ]; then echo "  Aliases:    $SSL_DOMAIN_ALIASES"; fi
     [ -n "$SSL_DOMAIN" ] && [ -n "$SSL_ADMIN_EMAIL" ] && echo "  SSL Email:  $SSL_ADMIN_EMAIL"
     if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ]; then
         echo "  HAProxy:    $HAPROXY_HOST (via $HAPROXY_NET)"
@@ -404,6 +424,14 @@ ssl_manager_run() {
             check_fail "SSL port $SSL_CHECK_PORT not listening"
         fi
         _ssl_check_cert "$CONTAINER_NAME" "$SSL_DOMAIN"
+        # Check alias certs
+        if [ -n "${SSL_DOMAIN_ALIASES:-}" ]; then
+            IFS=',' read -ra _hc_aliases <<< "$SSL_DOMAIN_ALIASES"
+            for _hca in "${_hc_aliases[@]}"; do
+                _hca=$(echo "$_hca" | xargs)
+                if [ -n "$_hca" ]; then _ssl_check_cert "$CONTAINER_NAME" "$_hca"; fi
+            done
+        fi
     fi
 
     # App-specific functional checks

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -38,6 +38,11 @@ handle_signal() {
         fi
     fi
 
+    # Stop the TLS alias proxy
+    if [ -n "$ALIAS_PROXY_PID" ] && kill -0 "$ALIAS_PROXY_PID" 2>/dev/null; then
+        kill "$ALIAS_PROXY_PID" 2>/dev/null || true
+    fi
+
     # Forward signal to supervisord (it will stop all managed processes)
     if [ -n "$SUPERVISOR_PID" ] && kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
         echo "[entrypoint] Forwarding $signal to supervisord (PID $SUPERVISOR_PID)..."
@@ -220,6 +225,33 @@ SUPERVISOR_PID=""
 /usr/bin/supervisord -c /etc/supervisord.conf &
 SUPERVISOR_PID=$!
 echo "[entrypoint] Supervisord started (PID $SUPERVISOR_PID)"
+
+# Step 7b: Start TLS alias proxy after supervisord (needs nginx on 443 to be ready)
+ALIAS_PROXY_PID=""
+if [ -f /tmp/.ssl-alias-proxy.pid ]; then
+    # ssl-setup started the proxy too early (before nginx). Restart it now.
+    old_pid=$(cat /tmp/.ssl-alias-proxy.pid 2>/dev/null)
+    kill "$old_pid" 2>/dev/null || true
+    sleep 2
+    echo "[entrypoint] Restarting TLS alias proxy (waiting for nginx)..."
+    # Wait for nginx to be ready on port 443
+    for _i in $(seq 1 30); do
+        if nc -z localhost 443 2>/dev/null; then break; fi
+        sleep 2
+    done
+    python3 /usr/local/bin/ssl-alias-proxy &
+    ALIAS_PROXY_PID=$!
+    echo "[entrypoint] TLS alias proxy restarted (PID $ALIAS_PROXY_PID)"
+elif [ -n "${SSL_DOMAIN_ALIASES:-}" ] && [ -f /tmp/.ssl-env ]; then
+    # Aliases configured but proxy wasn't started by ssl-setup (e.g., SSL_REQUIRED=false fallback)
+    for _i in $(seq 1 30); do
+        if nc -z localhost 443 2>/dev/null; then break; fi
+        sleep 2
+    done
+    python3 /usr/local/bin/ssl-alias-proxy &
+    ALIAS_PROXY_PID=$!
+    echo "[entrypoint] TLS alias proxy started (PID $ALIAS_PROXY_PID)"
+fi
 
 # Step 8: Watch for SSL renewal restart marker and supervisord exit
 # ssl-renew touches /tmp/.ssl-renewal-restart when certs are renewed;

--- a/scripts/gc-old-versions.py
+++ b/scripts/gc-old-versions.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+IPFS Garbage Collection: Remove old inventory versions.
+
+For each IPNS name in the sidecar database, keeps the N most recent
+inventory versions (following the _meta.lastCid chain) and unpins
+everything else.
+
+Uses the IPFS HTTP API directly (no subprocess overhead).
+
+Usage (run inside the ipfs-kubo container):
+    # Dry run (default) — show what would be unpinned
+    python3 /usr/local/bin/gc-old-versions.py
+
+    # Actually unpin
+    python3 /usr/local/bin/gc-old-versions.py --execute
+
+    # Keep 10 versions instead of 5
+    python3 /usr/local/bin/gc-old-versions.py --keep 10
+
+    # Process only first 100 IPNS names (for testing)
+    python3 /usr/local/bin/gc-old-versions.py --limit 100
+
+Or from the host:
+    docker exec ipfs-kubo python3 /usr/local/bin/gc-old-versions.py --execute
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+import urllib.request
+import urllib.error
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+IPFS_API = "http://127.0.0.1:5001"
+DB_PATH = "/data/ipfs/propagation.db"
+
+
+def ipfs_api(endpoint, timeout=10):
+    """Call IPFS HTTP API, return response body as bytes."""
+    url = f"{IPFS_API}{endpoint}"
+    req = urllib.request.Request(url, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except Exception:
+        return None
+
+
+def ipfs_cat(cid, timeout=10):
+    """Fetch content of a CID via IPFS API."""
+    data = ipfs_api(f"/api/v0/cat?arg={cid}", timeout=timeout)
+    if data:
+        return data.decode("utf-8", errors="replace")
+    return None
+
+
+def ipfs_pin_rm(cid):
+    """Unpin a CID via IPFS API."""
+    return ipfs_api(f"/api/v0/pin/rm?arg={cid}", timeout=30) is not None
+
+
+def ipfs_pin_ls_streaming():
+    """Stream all recursive pins from the IPFS API, yielding CIDs one at a time.
+
+    Uses the streaming JSON API to avoid buffering all output at once.
+    """
+    url = f"{IPFS_API}/api/v0/pin/ls?type=recursive&stream=true"
+    req = urllib.request.Request(url, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            buf = b""
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                        cid = obj.get("Cid", "")
+                        if cid:
+                            yield cid
+                    except json.JSONDecodeError:
+                        pass
+            # Handle remaining data
+            if buf.strip():
+                try:
+                    obj = json.loads(buf)
+                    cid = obj.get("Cid", "")
+                    if cid:
+                        yield cid
+                except json.JSONDecodeError:
+                    pass
+    except Exception as e:
+        print(f"[GC] ERROR streaming pins: {e}", file=sys.stderr)
+
+
+def ipfs_pin_ls_recursive():
+    """Get all recursively pinned CIDs as a set using streaming API."""
+    print("[GC] Loading all recursive pins (streaming)...", flush=True)
+    pins = set()
+    count = 0
+    start = time.time()
+    for cid in ipfs_pin_ls_streaming():
+        pins.add(cid)
+        count += 1
+        if count % 100000 == 0:
+            elapsed = time.time() - start
+            print(f"[GC]   ... loaded {count:,} pins ({elapsed:.0f}s)", flush=True)
+    elapsed = time.time() - start
+    print(f"[GC]   Loaded {count:,} pins in {elapsed:.0f}s", flush=True)
+    return pins
+
+
+def walk_chain(start_cid, keep_count):
+    """Walk the _meta.lastCid chain from start_cid, return list of CIDs to keep."""
+    keep = []
+    current = start_cid
+    for i in range(keep_count):
+        if not current:
+            break
+        keep.append(current)
+        content = ipfs_cat(current)
+        if not content:
+            break
+        try:
+            data = json.loads(content)
+            meta = data.get("_meta", {})
+            current = meta.get("lastCid")
+        except (json.JSONDecodeError, KeyError):
+            break
+    return keep
+
+
+def get_ipns_current_cids(db_path):
+    """Get all current IPNS name -> CID mappings from the sidecar DB."""
+    db = sqlite3.connect(db_path)
+    rows = db.execute(
+        "SELECT ipns_name, cid, sequence FROM ipns_records WHERE cid IS NOT NULL"
+    ).fetchall()
+    db.close()
+    return [(name, cid, seq) for name, cid, seq in rows]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IPFS GC: remove old inventory versions")
+    parser.add_argument("--keep", type=int, default=5, help="Number of recent versions to keep (default: 5)")
+    parser.add_argument("--execute", action="store_true", help="Actually unpin (default: dry run)")
+    parser.add_argument("--limit", type=int, default=0, help="Process only first N IPNS names (0=all)")
+    parser.add_argument("--skip-chain-walk", action="store_true",
+                        help="Skip chain walking — only protect current CID (faster but less safe)")
+    parser.add_argument("--skip-gc", action="store_true", help="Skip ipfs repo gc after unpinning")
+    parser.add_argument("--db-path", default=DB_PATH, help="Path to propagation.db")
+    args = parser.parse_args()
+
+    print(f"[GC] IPFS Inventory Garbage Collection", flush=True)
+    print(f"[GC] Keep: {args.keep} most recent versions per IPNS name", flush=True)
+    print(f"[GC] Mode: {'EXECUTE' if args.execute else 'DRY RUN'}", flush=True)
+    print(flush=True)
+
+    # Step 1: Load all recursive pins
+    all_pins = ipfs_pin_ls_recursive()
+    print(f"[GC] Total recursive pins: {len(all_pins):,}", flush=True)
+    if not all_pins:
+        print("[GC] ERROR: No pins found. Is the IPFS daemon running?")
+        sys.exit(1)
+
+    # Step 2: Get current IPNS -> CID mappings
+    ipns_records = get_ipns_current_cids(args.db_path)
+    print(f"[GC] IPNS names with CIDs: {len(ipns_records):,}", flush=True)
+
+    if args.limit > 0:
+        ipns_records = ipns_records[:args.limit]
+        print(f"[GC] Limited to first {args.limit} names", flush=True)
+
+    # Step 3: Build set of CIDs to KEEP (parallel chain walks)
+    keep_cids = set()
+    errors = 0
+    start_time = time.time()
+    total = len(ipns_records)
+    completed = 0
+
+    def process_one(record):
+        name, current_cid, seq = record
+        if args.skip_chain_walk:
+            return [current_cid], False
+        chain = walk_chain(current_cid, args.keep)
+        if chain:
+            return chain, False
+        return [current_cid], True  # error but still keep current
+
+    workers = 1 if args.skip_chain_walk else 20
+    print(f"[GC] Chain walk with {workers} workers...", flush=True)
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(process_one, rec): rec for rec in ipns_records}
+        for future in as_completed(futures):
+            completed += 1
+            chain, had_error = future.result()
+            keep_cids.update(chain)
+            if had_error:
+                errors += 1
+            if completed % 500 == 0:
+                elapsed = time.time() - start_time
+                rate = completed / elapsed if elapsed > 0 else 0
+                remaining = total - completed
+                eta = remaining / rate if rate > 0 else 0
+                print(f"[GC] Chain walk: {completed:,}/{total:,} "
+                      f"({rate:.0f}/s, keep={len(keep_cids):,}, "
+                      f"errors={errors}, ETA={eta/60:.0f}m)", flush=True)
+
+    elapsed = time.time() - start_time
+    print(flush=True)
+    print(f"[GC] Chain walk complete in {elapsed:.0f}s", flush=True)
+    print(f"[GC] CIDs to keep: {len(keep_cids):,}", flush=True)
+    print(f"[GC] Chain walk errors: {errors:,}", flush=True)
+
+    # Step 4: Calculate CIDs to unpin
+    to_unpin = all_pins - keep_cids
+    try:
+        db = sqlite3.connect(args.db_path)
+        nostr_cids = set(
+            row[0] for row in db.execute("SELECT cid FROM pinned_cids").fetchall()
+        )
+        db.close()
+        to_unpin -= nostr_cids
+        print(f"[GC] Nostr-pinned CIDs protected: {len(nostr_cids):,}", flush=True)
+    except Exception:
+        pass
+
+    print(f"[GC] CIDs to unpin: {len(to_unpin):,}", flush=True)
+    print(f"[GC] CIDs retained: {len(all_pins) - len(to_unpin):,}", flush=True)
+    print(flush=True)
+
+    if not to_unpin:
+        print("[GC] Nothing to unpin!")
+        return
+
+    # Step 5: Unpin
+    if not args.execute:
+        print("[GC] DRY RUN — no changes made. Run with --execute to unpin.", flush=True)
+        print(f"[GC] Would unpin {len(to_unpin):,} objects", flush=True)
+        return
+
+    print(f"[GC] Unpinning {len(to_unpin):,} CIDs...", flush=True)
+    unpinned = 0
+    failed = 0
+    start_time = time.time()
+
+    for cid in to_unpin:
+        if ipfs_pin_rm(cid):
+            unpinned += 1
+        else:
+            failed += 1
+
+        total = unpinned + failed
+        if total % 1000 == 0:
+            elapsed = time.time() - start_time
+            rate = total / elapsed if elapsed > 0 else 0
+            remaining = len(to_unpin) - total
+            eta = remaining / rate if rate > 0 else 0
+            print(f"[GC] Unpin: {total:,}/{len(to_unpin):,} "
+                  f"({rate:.0f}/s, ok={unpinned:,}, fail={failed:,}, "
+                  f"ETA={eta/60:.0f}m)", flush=True)
+
+    elapsed = time.time() - start_time
+    print(flush=True)
+    print(f"[GC] Unpinning complete in {elapsed:.0f}s", flush=True)
+    print(f"[GC] Unpinned: {unpinned:,}", flush=True)
+    print(f"[GC] Failed: {failed:,}", flush=True)
+
+    # Step 6: Run GC
+    if args.skip_gc:
+        print("[GC] Skipping ipfs repo gc (--skip-gc)", flush=True)
+        print("[GC] Run manually: docker exec ipfs-kubo sh -c 'IPFS_PATH=/data/ipfs ipfs repo gc'")
+        return
+
+    print(flush=True)
+    print("[GC] Running ipfs repo gc to reclaim disk space...", flush=True)
+    print("[GC] This may take a very long time for large repos...", flush=True)
+    try:
+        url = f"{IPFS_API}/api/v0/repo/gc"
+        req = urllib.request.Request(url, method="POST")
+        with urllib.request.urlopen(req, timeout=7200) as resp:
+            count = 0
+            buf = b""
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    count += 1
+                    if count % 100000 == 0:
+                        print(f"[GC]   GC removed {count:,} objects so far...", flush=True)
+            print(f"[GC] GC removed {count:,} objects", flush=True)
+    except Exception as e:
+        print(f"[GC] GC error: {e}", flush=True)
+        print("[GC] Run manually: docker exec ipfs-kubo sh -c 'IPFS_PATH=/data/ipfs ipfs repo gc'")
+
+    print(flush=True)
+    print("[GC] Done!", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `gc-old-versions.py` for one-time garbage collection of old inventory versions
- Add TLS alias proxy lifecycle management in entrypoint
- Update `run-lib.sh` from ssl-manager with multi-domain alias support

## GC Script

sphere-sdk uploads a new pinned CID on every inventory save but never unpins old versions. With 26K users and 1.65M accumulated pins, the datastore grew to 691GB (96% disk).

`gc-old-versions.py` walks `_meta.lastCid` chains, keeps 5 recent versions per IPNS name, unpins everything else. Successfully freed 598GB (96% → 28%).

## Alias Proxy Lifecycle

- Start TLS alias proxy AFTER supervisord (nginx must be ready on port 443)
- Kill stale proxy from ssl-setup, wait for nginx, restart
- Clean up alias proxy PID on graceful shutdown

## Test plan

- [x] GC script: freed 598GB, preserved peer identity and current inventories
- [x] Alias proxy starts after nginx, survives container lifecycle
- [x] Signal handler kills alias proxy on shutdown
- [x] run-lib.sh set -e fixes verified