### PR TITLE
fix(nginx): add /api/v0/dag/put location for UXF CAR uploads

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -207,6 +207,24 @@ http {
             proxy_pass_header Access-Control-Expose-Headers;
         }
 
+        # DAG put endpoint for UXF Profile CAR uploads (dag-cbor encoded blocks).
+        # sphere-sdk's CAR pin path posts dag-cbor blocks here via
+        # /api/v0/dag/put?input-codec=raw&store-codec=raw&pin=true. Without this
+        # location, nginx falls through to the gateway and returns 404 because
+        # the Kubo gateway (port 8080) does not expose the API surface.
+        location /api/v0/dag/put {
+            client_max_body_size 50M;
+            proxy_pass http://127.0.0.1:5001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 120s;
+            proxy_pass_header Access-Control-Allow-Origin;
+            proxy_pass_header Access-Control-Allow-Methods;
+            proxy_pass_header Access-Control-Allow-Headers;
+            proxy_pass_header Access-Control-Expose-Headers;
+        }
+
         # Safe API proxy for content preloading (refs triggers fetch via bitswap)
         location /api/v0/refs {
             client_max_body_size 10M;


### PR DESCRIPTION
## Summary

Restores `/api/v0/dag/put` proxy in the nginx config. It had been present as an uncommitted local edit on the production host and survived in the running container until I rebuilt the image yesterday from clean main, which silently dropped it.

sphere-sdk's CAR pin path uses `/api/v0/dag/put?input-codec=raw&store-codec=raw&pin=true` exclusively; every UXF Profile snapshot + bundle write was failing with HTTP 404 → `ORBITDB_WRITE_FAILED`. Blocked the issue #255 Stage B.1 manual-test characterization.

## Fix

Add `location /api/v0/dag/put { ... }` mirroring the sibling `/api/v0/add` block (50M body cap, 120s timeouts, direct pass-through to Kubo's API on port 5001).

## Test plan

After deploy:
```bash
echo test > /tmp/p
curl -sX POST 'https://ipfs.unicity.network/api/v0/dag/put?input-codec=raw&store-codec=raw&pin=true&hash=sha2-256' \
  -F 'data=@/tmp/p' -w '\nHTTP %{http_code}\n'
# Expected: {"Cid":{"/":"bafkrei..."}} HTTP 200
```