### PR TITLE
fix(nginx): partition proxy_cache_key by ?format and Accept

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -113,11 +113,22 @@ http {
             proxy_pass http://ipfs_gateway;
             proxy_cache ipfs_cache;
             proxy_cache_valid 200 7d;
-            proxy_cache_key $uri;
+
+            # CRITICAL: cache key MUST include format/codec selectors. The Kubo
+            # gateway picks the response codec based on both ?format=<x> and
+            # the Accept header (per IPIP-328 + the Gateway spec). A bare
+            # $uri cache key collides the dag-cbor (default) response with
+            # the CAR response (?format=car), poisoning the cache for any
+            # CID first fetched without ?format=car. Symptoms: 339-byte
+            # dag-cbor body served when CAR was requested; CarReader.fromBytes
+            # rejects the missing CAR magic header.
+            proxy_cache_key "$uri|format=$arg_format|accept=$http_accept";
+
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
             proxy_cache_lock on;
             add_header X-Cache-Status $upstream_cache_status;
+            add_header X-Cache-Key "$uri|format=$arg_format|accept=$http_accept" always;
 
             # NOTE: Do not override Accept header - Kubo 0.39+ runs in trustless mode
             # by default (Gateway.DeserializedResponses=null) and rejects non-trustless
@@ -142,7 +153,10 @@ http {
             proxy_pass http://ipfs_gateway;
             proxy_cache ipfs_cache;
             proxy_cache_valid 200 30s;
-            proxy_cache_key $uri;  # Ignore query params for stable caching
+            # See /ipfs/ above for the rationale. The Kubo gateway also
+            # honors ?format=<x>/Accept on /ipns/ — partition the cache by
+            # both so a CAR fetch does not pull a poisoned dag-cbor entry.
+            proxy_cache_key "$uri|format=$arg_format|accept=$http_accept";
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
             proxy_cache_lock on;


### PR DESCRIPTION
## Summary

The current `proxy_cache_key $uri` collides Kubo gateway responses across content-type variants for the same CID. The Kubo gateway picks the response codec from `?format=<x>` and `Accept` (per IPIP-328 + the Gateway spec); when a CID is first fetched without a format hint, the dag-cbor response gets cached, and any subsequent `?format=car` / `Accept: application/vnd.ipld.car` request serves the cached dag-cbor bytes with the wrong Content-Type. CarReader.fromBytes on the client then chokes on the missing CAR magic header.

Surfaced by sphere-sdk Stage B.1: Phase-3 walkback fetches of freshly-published Profile snapshots returned wrong content-type, `classifyVersion` reported SEMANTICALLY_INVALID, walkback hit the W7 floor with `AGGREGATOR_POINTER_WALKBACK_FLOOR`.

## Fix

Partition the cache by `URI | ?format= | Accept` for both `/ipfs/` and `/ipns/` locations. Echo the resulting key on an `X-Cache-Key` header for operator visibility.

## Verification

After deploy + cache purge:
```
CID=bafyreiciqk64nfcmbw7kldkegeuulsjmupqifvkqlirgamjgfiszydsaem
curl -sI "https://ipfs.unicity.network/ipfs/$CID?format=car" | grep -i content-type
# Expected: application/vnd.ipld.car; version=1; order=dfs; dups=n
curl -sI "https://ipfs.unicity.network/ipfs/$CID"           | grep -i content-type
# Expected: application/vnd.ipld.dag-cbor
```

Both Content-Types must hold under repeated requests (no cross-variant poisoning).