### PR TITLE
fix(nginx): add CORS headers to /sidecar/ location

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -287,7 +287,7 @@ http {
                 add_header Access-Control-Allow-Origin * always;
                 add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
                 add_header Access-Control-Allow-Headers "Content-Type, Accept" always;
-                add_header Access-Control-Max-Age 86400;
+                add_header Access-Control-Max-Age 86400 always;
                 add_header Content-Length 0;
                 add_header Content-Type text/plain;
                 return 204;

--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -273,13 +273,38 @@ http {
         # Instant-pin cache submit + read endpoints (issue #6).
         # Clients that hold the raw CAR/block bytes can POST them here to make
         # the CID retrievable instantly, before Kubo registers it.
+        #
+        # CORS: browser callers (sphere webpage, agentsphere, …) are
+        # cross-origin to this host. The sidecar service itself does not
+        # emit CORS headers, so nginx must handle preflight (OPTIONS) and
+        # add allow-origin to the POST/GET responses. Mirrors the pattern
+        # used by /api/v0/routing/get and /pin-status above.
         location /sidecar/ {
+            # Handle CORS preflight before passing to sidecar (which would
+            # otherwise 405 OPTIONS — observed on sphere-telco-test.dyndns.org
+            # blocking the CAR-block submit during UXF send pipeline).
+            if ($request_method = 'OPTIONS') {
+                add_header Access-Control-Allow-Origin * always;
+                add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+                add_header Access-Control-Allow-Headers "Content-Type, Accept" always;
+                add_header Access-Control-Max-Age 86400;
+                add_header Content-Length 0;
+                add_header Content-Type text/plain;
+                return 204;
+            }
+
             client_max_body_size 50M;
             proxy_pass http://sidecar;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_read_timeout 60s;
             proxy_send_timeout 60s;
+
+            # Add CORS headers to all responses (sidecar service doesn't add
+            # them itself). `always` so they're emitted on 4xx/5xx too.
+            add_header Access-Control-Allow-Origin * always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Content-Type, Accept" always;
         }
 
         # Add endpoint for direct content upload from browser


### PR DESCRIPTION
## Summary

The \`/sidecar/\` proxy block was the only browser-reachable endpoint in this nginx config without CORS handling — every cross-origin POST from a sphere webpage (e.g. \`https://sphere-telco-test.dyndns.org\` → \`https://unicity-ipfs1.dyndns.org\`) failed preflight and was blocked by the browser.

Symptom observed in production:

\`\`\`
Access to fetch at '.../sidecar/submit?cid=bafyrei…' from origin
'https://sphere-telco-test.dyndns.org' has been blocked by CORS policy:
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.

POST .../sidecar/submit?cid=… net::ERR_FAILED
  at submitToSidecarBestEffort → pinSingleBlock → pinCarBlocksToIpfs
  → resolveDelivery → sendInstantUxf
\`\`\`

\`submitToSidecarBestEffort\` is best-effort by name, but the CAR block never reaches IPFS, so the recipient cannot fetch the bundle and the send silently fails to deliver.

## Root cause

The browser sends OPTIONS preflight first (POST with \`Content-Type\` header triggers preflight). The \`/sidecar/\` block had no \`if (\$request_method = 'OPTIONS')\` handler — nginx falls through to \`proxy_pass http://sidecar\`, the sidecar service returns \`405 Method Not Allowed\`, no CORS headers are emitted, the browser refuses the actual POST.

## Fix

Mirror the CORS pattern already used by \`/api/v0/routing/get\`, \`/pin-status\`, and \`/ws/ipns\` in this same file:

- **OPTIONS preflight** → return 204 with standard \`allow-*\` headers (Origin \`*\`, Methods GET/POST/OPTIONS, Headers Content-Type/Accept, Max-Age 86400).
- **GET/POST responses** → same allow-\* headers, marked \`always\` so they're emitted on 4xx/5xx too.

## Verification

Patched live by editing \`/etc/nginx/nginx.conf\` in \`ipfs-kubo\` container and \`nginx -s reload\`. Re-ran the preflight from sphere-telco-test.dyndns.org:

\`\`\`
$ curl -sI -X OPTIONS https://unicity-ipfs1.dyndns.org/sidecar/submit \\
    -H "Origin: https://sphere-telco-test.dyndns.org" \\
    -H "Access-Control-Request-Method: POST" \\
    -H "Access-Control-Request-Headers: content-type"

HTTP/2 204
access-control-allow-origin: *
access-control-allow-methods: GET, POST, OPTIONS
access-control-allow-headers: Content-Type, Accept
access-control-max-age: 86400
\`\`\`

## Test plan

- [x] \`nginx -t\` passes (config syntax)
- [x] Live preflight returns 204 with correct CORS headers
- [x] Live POST from cross-origin browser no longer hits CORS block
- [ ] Image rebuild + container redeploy will replace the live-patched config with the committed template

## Why \`*\` origin

The /sidecar/ endpoint is intentionally browser-reachable from any sphere-derived webpage and any third-party UXF tool. Same posture as the existing \`*\` allow-origin on \`/api/v0/routing/get\` and \`/pin-status\` next to it.