### PR TITLE
feat(go-sidecar): eliminate Python memory leak via Go sidecar for routing-get, DHT refresh, and WebSocket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 # IPFS Storage Service with WSS Support
 # Based on ssl-manager for automatic SSL certificate management and HAProxy integration
 
+# ---- Go sidecar build stage (issue #17) ----
+# Builds the IPNS routing-get sidecar that replaces the Python hot path,
+# eliminating CPython pymalloc fragmentation under high-throughput reads.
+FROM golang:1.22-bookworm AS go-builder
+WORKDIR /build
+COPY go-sidecar/ ./
+RUN go mod tidy && CGO_ENABLED=1 go build -o /go-sidecar -ldflags="-s -w" .
+
+# ---- Main image ----
 FROM ghcr.io/unicitynetwork/ssl-manager:latest
 
 # ssl-manager is based on debian:trixie-slim and already includes:
@@ -53,6 +62,10 @@ RUN pip3 install --no-cache-dir --break-system-packages -r /tmp/nostr-requiremen
 COPY nostr-pinner/nostr_pinner.py /usr/local/bin/nostr_pinner.py
 COPY nostr-pinner/instant_pin_cache.py /usr/local/bin/instant_pin_cache.py
 RUN chmod 644 /usr/local/bin/nostr_pinner.py /usr/local/bin/instant_pin_cache.py
+
+# Copy Go sidecar binary (issue #17: IPNS routing-get + DHT refresh)
+COPY --from=go-builder /go-sidecar /usr/local/bin/go-sidecar
+RUN chmod 755 /usr/local/bin/go-sidecar
 
 # Copy configuration files
 COPY config/supervisord.conf /etc/supervisord.conf
@@ -107,6 +120,12 @@ ENV DOMAIN=localhost \
     SIDECAR_CACHE_MAX_BLOB_BYTES="33554432" \
     SIDECAR_CACHE_RECONCILE_INTERVAL="5" \
     SIDECAR_CACHE_PROMOTION_TIMEOUT="86400" \
-    SIDECAR_CACHE_KUBO_TIMEOUT="30"
+    SIDECAR_CACHE_KUBO_TIMEOUT="30" \
+    # Go sidecar configuration (issue #17: IPNS routing-get + DHT refresh)
+    GO_SIDECAR_PORT="9082" \
+    REFRESH_INTERVAL_SECONDS="10" \
+    REFRESH_BATCH_SIZE="50" \
+    MAX_REFRESH_CONCURRENCY="10" \
+    PYTHON_SIDECAR_URL="http://127.0.0.1:9081"
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -79,9 +79,15 @@ http {
         server 127.0.0.1:8080;
     }
 
-    # Upstream to sidecar service (for fast-path IPNS/pin lookups)
+    # Upstream to Python sidecar service (IPNS writes, pin lookups, WebSocket, cache)
     upstream sidecar {
         server 127.0.0.1:9081;
+    }
+
+    # Upstream to Go sidecar (issue #17: IPNS routing-get reads + DHT refresh)
+    # Eliminates CPython pymalloc fragmentation on the hot read path.
+    upstream go_sidecar {
+        server 127.0.0.1:9082;
     }
 
     # HTTPS Gateway server
@@ -378,8 +384,8 @@ http {
             proxy_cache_bypass $http_x_no_cache;
             add_header X-Routing-Cache $upstream_cache_status always;
 
-            # Try sidecar first (instant DB lookup)
-            proxy_pass http://sidecar/routing-get$is_args$args;
+            # Try Go sidecar first (instant DB lookup, issue #17)
+            proxy_pass http://go_sidecar/routing-get$is_args$args;
             proxy_connect_timeout 1s;
             proxy_read_timeout 2s;
             proxy_set_header Host $host;

--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -426,10 +426,10 @@ http {
             add_header Access-Control-Allow-Headers "Content-Type" always;
         }
 
-        # WebSocket endpoint for IPNS subscription updates
+        # WebSocket endpoint for IPNS subscription updates (issue #17: moved to Go sidecar)
         # Clients subscribe to IPNS names and receive push notifications on updates
         location /ws/ipns {
-            proxy_pass http://sidecar/ws/ipns;
+            proxy_pass http://go_sidecar/ws/ipns;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -82,6 +82,24 @@ stderr_logfile_maxbytes=0
 environment=IPFS_PATH="/data/ipfs",HOME="/data/ipfs"
 priority=300
 
+# Go Sidecar (continuous) — issue #17
+# Handles IPNS /routing-get reads and background DHT refresh.
+# Replaces the Python hot path to eliminate CPython pymalloc fragmentation.
+# Must start after IPFS (needs kubo API) and before nostr-pinner (shares SQLite).
+[program:go-sidecar]
+command=/usr/local/bin/go-sidecar
+autostart=true
+autorestart=true
+startsecs=5
+startretries=3
+stopwaitsecs=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment=IPFS_API_URL="http://127.0.0.1:5001",DB_PATH="/data/ipfs/propagation.db"
+priority=350
+
 # Nostr Pin Service (continuous)
 # Subscribes to Nostr relays and pins announced CIDs
 [program:nostr-pinner]

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -88,6 +88,7 @@ priority=300
 # Must start after IPFS (needs kubo API) and before nostr-pinner (shares SQLite).
 [program:go-sidecar]
 command=/usr/local/bin/go-sidecar
+user=ipfs
 autostart=true
 autorestart=true
 startsecs=5

--- a/go-sidecar/go.mod
+++ b/go-sidecar/go.mod
@@ -1,0 +1,5 @@
+module github.com/unicitynetwork/ipfs-storage/go-sidecar
+
+go 1.22
+
+require github.com/mattn/go-sqlite3 v1.14.24

--- a/go-sidecar/go.mod
+++ b/go-sidecar/go.mod
@@ -2,4 +2,7 @@ module github.com/unicitynetwork/ipfs-storage/go-sidecar
 
 go 1.22
 
-require github.com/mattn/go-sqlite3 v1.14.24
+require (
+	github.com/gorilla/websocket v1.5.3
+	github.com/mattn/go-sqlite3 v1.14.24
+)

--- a/go-sidecar/handlers.go
+++ b/go-sidecar/handlers.go
@@ -155,11 +155,30 @@ func (h *Handler) triggerAsyncRefresh(ipnsName string, dbSequence int64) {
 			responseJSON := buildResponseJSON(recordBytes)
 			_, cid := parseIPNSRecord(recordBytes)
 			h.store.WriteRecord(ipnsName, recordBytes, responseJSON, seq, cid)
-			h.store.NotifyPython(ipnsName, seq, cid)
+			h.store.NotifyWS(ipnsName, seq, cid)
 		} else {
 			h.store.TouchTimestamp(ipnsName)
 		}
 	}()
+}
+
+// WSNotify handles POST /internal/ws-notify?name=...&sequence=...&cid=...
+// Called by Python ipns-intercept after storing a new IPNS record,
+// so Go can push the update to connected WebSocket subscribers.
+func (h *Handler) WSNotify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ipnsName := r.URL.Query().Get("name")
+	seqStr := r.URL.Query().Get("sequence")
+	cid := r.URL.Query().Get("cid")
+
+	seq, _ := strconv.ParseInt(seqStr, 10, 64)
+	if ipnsName != "" && seq > 0 {
+		h.store.NotifyWS(ipnsName, seq, cid)
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // Health returns a simple health check response.

--- a/go-sidecar/handlers.go
+++ b/go-sidecar/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"sync"
@@ -189,7 +190,7 @@ func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
 
 // fetchFromKubo fetches an IPNS record from the kubo DHT API.
 func fetchFromKubo(client *http.Client, kuboURL, ipnsName string) ([]byte, int64, error) {
-	url := fmt.Sprintf("%s/api/v0/routing/get?arg=/ipns/%s", kuboURL, ipnsName)
+	url := fmt.Sprintf("%s/api/v0/routing/get?arg=%s", kuboURL, url.QueryEscape("/ipns/"+ipnsName))
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return nil, 0, err

--- a/go-sidecar/handlers.go
+++ b/go-sidecar/handlers.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var argRE = regexp.MustCompile(`^/ipns/(.+)$`)
+
+// Handler serves HTTP requests for the Go sidecar.
+type Handler struct {
+	db         *sql.DB
+	cfg        Config
+	kuboClient *http.Client
+	store      *Store
+
+	// Track in-flight background refreshes to prevent duplicates.
+	mu              sync.Mutex
+	refreshInFlight map[string]struct{}
+}
+
+// RoutingGet handles GET/POST /routing-get?arg=/ipns/{name}.
+//
+// Flow:
+//  1. Query SQLite for cached response_cache (5-20ms)
+//  2. If found, return immediately; trigger async refresh if stale
+//  3. If not found, blocking DHT fetch via kubo, store, return
+func (h *Handler) RoutingGet(w http.ResponseWriter, r *http.Request) {
+	arg := r.URL.Query().Get("arg")
+	m := argRE.FindStringSubmatch(arg)
+	if m == nil {
+		http.Error(w, "Invalid arg format", http.StatusBadRequest)
+		return
+	}
+	ipnsName := m[1]
+
+	if !isValidIPNSName(ipnsName) {
+		http.Error(w, "Invalid IPNS name", http.StatusBadRequest)
+		return
+	}
+
+	// 1. Query SQLite.
+	var responseCache sql.NullString
+	var marshalledRecord []byte
+	var sequence int64
+	var lastUpdated sql.NullString
+	err := h.db.QueryRow(
+		`SELECT response_cache, marshalled_record, COALESCE(sequence, 0), last_updated
+		 FROM ipns_records WHERE ipns_name = ?`, ipnsName,
+	).Scan(&responseCache, &marshalledRecord, &sequence, &lastUpdated)
+
+	if err == sql.ErrNoRows {
+		// Not in cache — blocking DHT fetch.
+		h.fetchFromDHTAndStore(w, ipnsName)
+		return
+	}
+	if err != nil {
+		log.Printf("routing-get: DB error for %s: %v", truncate(ipnsName), err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Compute response body.
+	var body string
+	if responseCache.Valid && responseCache.String != "" {
+		body = responseCache.String
+	} else {
+		body = buildResponseJSON(marshalledRecord)
+	}
+
+	// Calculate age and staleness.
+	ageSeconds := 0
+	isStale := true
+	if lastUpdated.Valid && lastUpdated.String != "" {
+		if t, err := parseTimestamp(lastUpdated.String); err == nil {
+			ageSeconds = int(time.Since(t).Seconds())
+			isStale = ageSeconds > h.cfg.StaleThresholdSeconds
+		}
+	}
+
+	// If stale, trigger non-blocking background refresh.
+	if isStale {
+		h.triggerAsyncRefresh(ipnsName, sequence)
+	}
+
+	// Return cached response.
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-IPNS-Source", "go-sidecar")
+	w.Header().Set("X-IPNS-Sequence", strconv.FormatInt(sequence, 10))
+	if lastUpdated.Valid {
+		w.Header().Set("X-IPNS-Last-Updated", lastUpdated.String)
+	}
+	w.Header().Set("X-IPNS-Age", strconv.Itoa(ageSeconds))
+	w.Header().Set("X-IPNS-Stale", strconv.FormatBool(isStale))
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, stale-while-revalidate=30", h.cfg.StaleThresholdSeconds))
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, body)
+}
+
+// fetchFromDHTAndStore does a blocking DHT fetch for records not in SQLite.
+func (h *Handler) fetchFromDHTAndStore(w http.ResponseWriter, ipnsName string) {
+	recordBytes, seq, err := fetchFromKubo(h.kuboClient, h.cfg.KuboAPIURL, ipnsName)
+	if err != nil {
+		log.Printf("routing-get: DHT fetch error for %s: %v", truncate(ipnsName), err)
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	responseJSON := buildResponseJSON(recordBytes)
+	_, cid := parseIPNSRecord(recordBytes)
+	h.store.WriteRecord(ipnsName, recordBytes, responseJSON, seq, cid)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-IPNS-Source", "kubo")
+	w.Header().Set("X-IPNS-Sequence", strconv.FormatInt(seq, 10))
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, responseJSON)
+}
+
+// triggerAsyncRefresh starts a background goroutine to refresh a stale record.
+func (h *Handler) triggerAsyncRefresh(ipnsName string, dbSequence int64) {
+	h.mu.Lock()
+	if _, ok := h.refreshInFlight[ipnsName]; ok {
+		h.mu.Unlock()
+		return
+	}
+	if len(h.refreshInFlight) >= h.cfg.MaxRefreshConcurrency {
+		h.mu.Unlock()
+		return
+	}
+	h.refreshInFlight[ipnsName] = struct{}{}
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			h.mu.Lock()
+			delete(h.refreshInFlight, ipnsName)
+			h.mu.Unlock()
+		}()
+
+		recordBytes, seq, err := fetchFromKubo(h.kuboClient, h.cfg.KuboAPIURL, ipnsName)
+		if err != nil {
+			return
+		}
+
+		if seq > dbSequence {
+			responseJSON := buildResponseJSON(recordBytes)
+			_, cid := parseIPNSRecord(recordBytes)
+			h.store.WriteRecord(ipnsName, recordBytes, responseJSON, seq, cid)
+			h.store.NotifyPython(ipnsName, seq, cid)
+		} else {
+			h.store.TouchTimestamp(ipnsName)
+		}
+	}()
+}
+
+// Health returns a simple health check response.
+func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	io.WriteString(w, "ok\n")
+}
+
+// fetchFromKubo fetches an IPNS record from the kubo DHT API.
+func fetchFromKubo(client *http.Client, kuboURL, ipnsName string) ([]byte, int64, error) {
+	url := fmt.Sprintf("%s/api/v0/routing/get?arg=/ipns/%s", kuboURL, ipnsName)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return nil, 0, fmt.Errorf("kubo returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	extraB64 := extractExtraField(body)
+	if extraB64 == "" {
+		return nil, 0, fmt.Errorf("no Extra field in kubo response")
+	}
+
+	recordBytes, err := base64.StdEncoding.DecodeString(extraB64)
+	if err != nil {
+		return nil, 0, fmt.Errorf("base64 decode: %w", err)
+	}
+
+	seq, _ := parseIPNSRecord(recordBytes)
+	return recordBytes, seq, nil
+}
+
+// parseTimestamp handles SQLite timestamp formats.
+func parseTimestamp(s string) (time.Time, error) {
+	for _, layout := range []string{
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05+00:00",
+		"2006-01-02T15:04:05.000000",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unparseable timestamp: %s", s)
+}
+
+func truncate(s string) string {
+	if len(s) > 16 {
+		return s[:16] + "..."
+	}
+	return s
+}

--- a/go-sidecar/ipns.go
+++ b/go-sidecar/ipns.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/base64"
+	"regexp"
+)
+
+// IPNS name validation: 12D3KooW... (PeerID) or k... (CIDv1 libp2p-key).
+var ipnsNameRE = regexp.MustCompile(`^(12D3KooW[a-zA-Z0-9]{44}|k[a-z2-7]{50,})$`)
+
+// Regex to extract base64-encoded "Extra" field from kubo routing/get JSON.
+// Matches: "Extra":"<base64>"
+var extraFieldRE = regexp.MustCompile(`"Extra"\s*:\s*"([A-Za-z0-9+/=]+)"`)
+
+// isValidIPNSName checks whether the given string looks like a valid IPNS name.
+func isValidIPNSName(name string) bool {
+	return ipnsNameRE.MatchString(name)
+}
+
+// extractExtraField pulls the base64 "Extra" value from a raw kubo
+// routing/get JSON response without parsing the full JSON tree.
+func extractExtraField(body []byte) string {
+	m := extraFieldRE.FindSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	return string(m[1])
+}
+
+// buildResponseJSON constructs the pre-serialized routing-get JSON response
+// for a marshalled IPNS record: {"Extra":"<base64>","Type":5}
+func buildResponseJSON(marshalledRecord []byte) string {
+	return `{"Extra":"` + base64.StdEncoding.EncodeToString(marshalledRecord) + `","Type":5}`
+}
+
+// parseIPNSRecord extracts the sequence number (field 5) and CID
+// from a protobuf-encoded IPNS record.
+//
+// IPNS record fields:
+//   - field 1 (bytes): value (path like /ipfs/<cid>)
+//   - field 5 (varint): sequence number
+func parseIPNSRecord(data []byte) (sequence int64, cid string) {
+	var value string
+	pos := 0
+	for pos < len(data) {
+		// Read field key (varint).
+		key, n := readVarint(data[pos:])
+		if n == 0 {
+			break
+		}
+		pos += n
+
+		fieldNumber := key >> 3
+		wireType := key & 0x07
+
+		switch wireType {
+		case 0: // Varint
+			val, n := readVarint(data[pos:])
+			if n == 0 {
+				return sequence, cid
+			}
+			pos += n
+			if fieldNumber == 5 {
+				sequence = int64(val)
+			}
+
+		case 2: // Length-delimited
+			length, n := readVarint(data[pos:])
+			if n == 0 {
+				return sequence, cid
+			}
+			pos += n
+			if pos+int(length) > len(data) {
+				return sequence, cid
+			}
+			fieldData := data[pos : pos+int(length)]
+			pos += int(length)
+			if fieldNumber == 1 {
+				value = string(fieldData)
+			}
+
+		default:
+			// Unknown wire type — cannot safely skip without knowing the
+			// encoding. Stop parsing rather than risk misinterpreting data.
+			return sequence, cid
+		}
+	}
+
+	// Extract CID from value (e.g., "/ipfs/bafyrei...")
+	if len(value) > 6 && value[:6] == "/ipfs/" {
+		cid = value[6:]
+	}
+	return sequence, cid
+}
+
+// readVarint reads a protobuf varint from buf and returns (value, bytes_consumed).
+// Returns (0, 0) on error.
+func readVarint(buf []byte) (uint64, int) {
+	var val uint64
+	var shift uint
+	for i, b := range buf {
+		if i >= 10 { // varint too long
+			return 0, 0
+		}
+		val |= uint64(b&0x7F) << shift
+		if b&0x80 == 0 {
+			return val, i + 1
+		}
+		shift += 7
+	}
+	return 0, 0
+}

--- a/go-sidecar/ipns.go
+++ b/go-sidecar/ipns.go
@@ -79,9 +79,14 @@ func parseIPNSRecord(data []byte) (sequence int64, cid string) {
 				value = string(fieldData)
 			}
 
+		case 1: // 64-bit fixed (double, fixed64, sfixed64)
+			pos += 8
+
+		case 5: // 32-bit fixed (float, fixed32, sfixed32)
+			pos += 4
+
 		default:
-			// Unknown wire type — cannot safely skip without knowing the
-			// encoding. Stop parsing rather than risk misinterpreting data.
+			// Unknown wire type — cannot safely skip.
 			return sequence, cid
 		}
 	}

--- a/go-sidecar/main.go
+++ b/go-sidecar/main.go
@@ -1,12 +1,13 @@
-// Go sidecar for IPNS routing-get and DHT refresh.
+// Go sidecar for IPNS routing-get, DHT refresh, and WebSocket subscriptions.
 //
 // Eliminates CPython pymalloc fragmentation (issue #17) by moving the
-// high-throughput read path and DHT refresh out of the Python pinner
-// into a compiled binary with predictable memory behaviour.
+// high-throughput read path, DHT refresh, and WebSocket connections out
+// of the Python pinner into a compiled binary with predictable memory.
 //
 // Shares the SQLite database with the Python pinner via WAL mode.
 // Python handles writes (ipns-intercept, chain validation, Nostr).
-// Go handles reads (/routing-get) and background DHT refresh.
+// Go handles reads (/routing-get), background DHT refresh, and
+// WebSocket push notifications (/ws/ipns).
 package main
 
 import (
@@ -32,7 +33,6 @@ type Config struct {
 	RefreshInterval       time.Duration
 	RefreshBatchSize      int
 	MaxRefreshConcurrency int
-	PythonSidecarURL      string
 }
 
 func loadConfig() Config {
@@ -43,7 +43,6 @@ func loadConfig() Config {
 		StaleThresholdSeconds: envOrInt("STALE_THRESHOLD_SECONDS", 60),
 		RefreshBatchSize:      envOrInt("REFRESH_BATCH_SIZE", 50),
 		MaxRefreshConcurrency: envOrInt("MAX_REFRESH_CONCURRENCY", 10),
-		PythonSidecarURL:      envOr("PYTHON_SIDECAR_URL", "http://127.0.0.1:9081"),
 	}
 	c.RefreshInterval = time.Duration(envOrInt("REFRESH_INTERVAL_SECONDS", 10)) * time.Second
 	return c
@@ -90,13 +89,12 @@ func main() {
 		},
 	}
 
-	// Notification client for Python sidecar WS callbacks (short timeout).
-	notifyClient := &http.Client{Timeout: 2 * time.Second}
+	// WebSocket subscription manager (Go now owns all WS connections).
+	subMgr := NewSubscriptionManager()
 
 	store := &Store{
-		db:           db,
-		notifyClient: notifyClient,
-		pythonURL:    cfg.PythonSidecarURL,
+		db:     db,
+		subMgr: subMgr,
 	}
 
 	handler := &Handler{
@@ -116,13 +114,16 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/routing-get", handler.RoutingGet)
+	mux.HandleFunc("/ws/ipns", subMgr.HandleWebSocket)
+	mux.HandleFunc("/internal/ws-notify", handler.WSNotify)
 	mux.HandleFunc("/health", handler.Health)
 
 	srv := &http.Server{
-		Addr:         cfg.ListenAddr,
-		Handler:      mux,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:    cfg.ListenAddr,
+		Handler: mux,
+		// No global ReadTimeout — WebSocket connections are long-lived.
+		// Per-request timeouts are handled in handlers.
+		WriteTimeout: 0, // Disabled for WS; routing-get sets its own.
 		IdleTimeout:  60 * time.Second,
 	}
 
@@ -132,7 +133,7 @@ func main() {
 	go refresher.Run(ctx)
 
 	go func() {
-		log.Printf("Go sidecar listening on %s", cfg.ListenAddr)
+		log.Printf("Go sidecar listening on %s (routing-get, ws/ipns, ws-notify)", cfg.ListenAddr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Server error: %v", err)
 		}

--- a/go-sidecar/main.go
+++ b/go-sidecar/main.go
@@ -1,0 +1,150 @@
+// Go sidecar for IPNS routing-get and DHT refresh.
+//
+// Eliminates CPython pymalloc fragmentation (issue #17) by moving the
+// high-throughput read path and DHT refresh out of the Python pinner
+// into a compiled binary with predictable memory behaviour.
+//
+// Shares the SQLite database with the Python pinner via WAL mode.
+// Python handles writes (ipns-intercept, chain validation, Nostr).
+// Go handles reads (/routing-get) and background DHT refresh.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Config holds runtime configuration from environment variables.
+type Config struct {
+	ListenAddr            string
+	DBPath                string
+	KuboAPIURL            string
+	StaleThresholdSeconds int
+	RefreshInterval       time.Duration
+	RefreshBatchSize      int
+	MaxRefreshConcurrency int
+	PythonSidecarURL      string
+}
+
+func loadConfig() Config {
+	c := Config{
+		ListenAddr:            ":" + envOr("GO_SIDECAR_PORT", "9082"),
+		DBPath:                envOr("DB_PATH", "/data/ipfs/propagation.db"),
+		KuboAPIURL:            envOr("IPFS_API_URL", "http://127.0.0.1:5001"),
+		StaleThresholdSeconds: envOrInt("STALE_THRESHOLD_SECONDS", 60),
+		RefreshBatchSize:      envOrInt("REFRESH_BATCH_SIZE", 50),
+		MaxRefreshConcurrency: envOrInt("MAX_REFRESH_CONCURRENCY", 10),
+		PythonSidecarURL:      envOr("PYTHON_SIDECAR_URL", "http://127.0.0.1:9081"),
+	}
+	c.RefreshInterval = time.Duration(envOrInt("REFRESH_INTERVAL_SECONDS", 10)) * time.Second
+	return c
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envOrInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func main() {
+	cfg := loadConfig()
+
+	// Open SQLite in WAL mode, read-write (needed for DHT refresh writes).
+	db, err := sql.Open("sqlite3", cfg.DBPath+"?_journal_mode=WAL&_busy_timeout=5000&cache=shared")
+	if err != nil {
+		log.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatalf("Database ping failed: %v", err)
+	}
+	log.Printf("Connected to SQLite: %s", cfg.DBPath)
+
+	// HTTP client for kubo API calls.
+	kuboClient := &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        20,
+			MaxIdleConnsPerHost: 20,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	// Notification client for Python sidecar WS callbacks (short timeout).
+	notifyClient := &http.Client{Timeout: 2 * time.Second}
+
+	store := &Store{
+		db:           db,
+		notifyClient: notifyClient,
+		pythonURL:    cfg.PythonSidecarURL,
+	}
+
+	handler := &Handler{
+		db:              db,
+		cfg:             cfg,
+		kuboClient:      kuboClient,
+		store:           store,
+		refreshInFlight: make(map[string]struct{}),
+	}
+
+	refresher := &Refresher{
+		db:         db,
+		cfg:        cfg,
+		kuboClient: kuboClient,
+		store:      store,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/routing-get", handler.RoutingGet)
+	mux.HandleFunc("/health", handler.Health)
+
+	srv := &http.Server{
+		Addr:         cfg.ListenAddr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go refresher.Run(ctx)
+
+	go func() {
+		log.Printf("Go sidecar listening on %s", cfg.ListenAddr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("Shutting down...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Shutdown error: %v", err)
+	}
+	log.Println("Go sidecar stopped")
+}

--- a/go-sidecar/main.go
+++ b/go-sidecar/main.go
@@ -121,10 +121,11 @@ func main() {
 	srv := &http.Server{
 		Addr:    cfg.ListenAddr,
 		Handler: mux,
-		// No global ReadTimeout — WebSocket connections are long-lived.
-		// Per-request timeouts are handled in handlers.
-		WriteTimeout: 0, // Disabled for WS; routing-get sets its own.
-		IdleTimeout:  60 * time.Second,
+		// ReadHeaderTimeout limits only the header-reading phase, which is
+		// safe for WebSocket connections (timeout fires before upgrade).
+		// No global ReadTimeout or WriteTimeout — WS connections are long-lived.
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/go-sidecar/refresh.go
+++ b/go-sidecar/refresh.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Refresher periodically scans for stale IPNS records and refreshes them
+// from the kubo DHT. This replaces the Python _refresh_and_push and
+// DhtSyncWorker, eliminating CPython pymalloc fragmentation from
+// high-throughput HTTP + base64 allocations.
+type Refresher struct {
+	db         *sql.DB
+	cfg        Config
+	kuboClient *http.Client
+	store      *Store
+}
+
+// Run starts the periodic refresh loop. Blocks until ctx is cancelled.
+func (r *Refresher) Run(ctx context.Context) {
+	log.Printf("DHT refresh worker started (interval=%s, stale=%ds, batch=%d, concurrency=%d)",
+		r.cfg.RefreshInterval, r.cfg.StaleThresholdSeconds,
+		r.cfg.RefreshBatchSize, r.cfg.MaxRefreshConcurrency)
+
+	ticker := time.NewTicker(r.cfg.RefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("DHT refresh worker stopped")
+			return
+		case <-ticker.C:
+			r.refreshBatch(ctx)
+		}
+	}
+}
+
+// refreshBatch finds stale records and refreshes them concurrently.
+func (r *Refresher) refreshBatch(ctx context.Context) {
+	staleThreshold := fmt.Sprintf("-%d seconds", r.cfg.StaleThresholdSeconds)
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT ipns_name, COALESCE(sequence, 0) as sequence
+		 FROM ipns_records
+		 WHERE last_updated < datetime('now', ?)
+		 ORDER BY last_updated ASC
+		 LIMIT ?`,
+		staleThreshold, r.cfg.RefreshBatchSize,
+	)
+	if err != nil {
+		log.Printf("refresh: query error: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type staleRecord struct {
+		name     string
+		sequence int64
+	}
+	var stale []staleRecord
+	for rows.Next() {
+		var sr staleRecord
+		if err := rows.Scan(&sr.name, &sr.sequence); err != nil {
+			continue
+		}
+		stale = append(stale, sr)
+	}
+
+	if len(stale) == 0 {
+		return
+	}
+
+	log.Printf("refresh: processing %d stale records", len(stale))
+
+	sem := make(chan struct{}, r.cfg.MaxRefreshConcurrency)
+	var wg sync.WaitGroup
+
+	for _, sr := range stale {
+		if ctx.Err() != nil {
+			break
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(name string, seq int64) {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+			r.refreshSingle(name, seq)
+		}(sr.name, sr.sequence)
+	}
+
+	wg.Wait()
+}
+
+// refreshSingle refreshes a single IPNS record from the kubo DHT.
+func (r *Refresher) refreshSingle(ipnsName string, dbSequence int64) {
+	recordBytes, seq, err := fetchFromKubo(r.kuboClient, r.cfg.KuboAPIURL, ipnsName)
+	if err != nil {
+		// Touch timestamp to avoid retrying immediately.
+		r.store.TouchTimestamp(ipnsName)
+		return
+	}
+
+	if seq > dbSequence {
+		responseJSON := buildResponseJSON(recordBytes)
+		_, cid := parseIPNSRecord(recordBytes)
+		r.store.WriteRecord(ipnsName, recordBytes, responseJSON, seq, cid)
+		r.store.NotifyPython(ipnsName, seq, cid)
+		log.Printf("refresh: updated %s seq %d→%d", truncate(ipnsName), dbSequence, seq)
+	} else {
+		r.store.TouchTimestamp(ipnsName)
+	}
+}
+

--- a/go-sidecar/refresh.go
+++ b/go-sidecar/refresh.go
@@ -112,7 +112,7 @@ func (r *Refresher) refreshSingle(ipnsName string, dbSequence int64) {
 		responseJSON := buildResponseJSON(recordBytes)
 		_, cid := parseIPNSRecord(recordBytes)
 		r.store.WriteRecord(ipnsName, recordBytes, responseJSON, seq, cid)
-		r.store.NotifyPython(ipnsName, seq, cid)
+		r.store.NotifyWS(ipnsName, seq, cid)
 		log.Printf("refresh: updated %s seq %d→%d", truncate(ipnsName), dbSequence, seq)
 	} else {
 		r.store.TouchTimestamp(ipnsName)

--- a/go-sidecar/store.go
+++ b/go-sidecar/store.go
@@ -2,17 +2,13 @@ package main
 
 import (
 	"database/sql"
-	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 )
 
-// Store encapsulates shared SQLite write operations and Python notification.
+// Store encapsulates shared SQLite write operations and WebSocket notifications.
 type Store struct {
-	db           *sql.DB
-	notifyClient *http.Client
-	pythonURL    string
+	db     *sql.DB
+	subMgr *SubscriptionManager
 }
 
 // WriteRecord inserts or updates an IPNS record in SQLite.
@@ -57,15 +53,10 @@ func (s *Store) TouchTimestamp(ipnsName string) {
 	)
 }
 
-// NotifyPython sends a POST to the Python sidecar's /internal/ws-notify
-// endpoint so it can push updates to connected WebSocket subscribers.
-// Failures are non-critical — WS clients will get updates on next poll.
-func (s *Store) NotifyPython(ipnsName string, sequence int64, cid string) {
-	notifyURL := fmt.Sprintf("%s/internal/ws-notify?name=%s&sequence=%d&cid=%s",
-		s.pythonURL, url.QueryEscape(ipnsName), sequence, url.QueryEscape(cid))
-	resp, err := s.notifyClient.Post(notifyURL, "", nil)
-	if err != nil {
-		return
+// NotifyWS pushes an IPNS update to all WebSocket subscribers.
+// Called after DHT refresh finds a newer record.
+func (s *Store) NotifyWS(ipnsName string, sequence int64, cid string) {
+	if s.subMgr != nil {
+		s.subMgr.Notify(ipnsName, sequence, cid)
 	}
-	resp.Body.Close()
 }

--- a/go-sidecar/store.go
+++ b/go-sidecar/store.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// Store encapsulates shared SQLite write operations and Python notification.
+type Store struct {
+	db           *sql.DB
+	notifyClient *http.Client
+	pythonURL    string
+}
+
+// WriteRecord inserts or updates an IPNS record in SQLite.
+// Uses a simple sequence check — no chain validation (that's Python's concern
+// on the ipns-intercept write path).
+func (s *Store) WriteRecord(ipnsName string, marshalledRecord []byte, responseJSON string, sequence int64, cid string) {
+	// Try UPDATE first (most common case for refresh).
+	res, err := s.db.Exec(
+		`UPDATE ipns_records
+		 SET marshalled_record = ?, response_cache = ?, sequence = ?, cid = ?,
+		     last_updated = datetime('now')
+		 WHERE ipns_name = ? AND COALESCE(sequence, 0) < ?`,
+		marshalledRecord, responseJSON, sequence, cid, ipnsName, sequence,
+	)
+	if err != nil {
+		log.Printf("storeRecord UPDATE error: %v", err)
+		return
+	}
+
+	rows, _ := res.RowsAffected()
+	if rows > 0 {
+		return
+	}
+
+	// If no rows updated, try INSERT (new record).
+	_, err = s.db.Exec(
+		`INSERT OR IGNORE INTO ipns_records
+		 (ipns_name, marshalled_record, response_cache, sequence, cid, last_updated)
+		 VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+		ipnsName, marshalledRecord, responseJSON, sequence, cid,
+	)
+	if err != nil {
+		log.Printf("storeRecord INSERT error: %v", err)
+	}
+}
+
+// TouchTimestamp updates last_updated without changing record data.
+func (s *Store) TouchTimestamp(ipnsName string) {
+	s.db.Exec(
+		`UPDATE ipns_records SET last_updated = datetime('now') WHERE ipns_name = ?`,
+		ipnsName,
+	)
+}
+
+// NotifyPython sends a POST to the Python sidecar's /internal/ws-notify
+// endpoint so it can push updates to connected WebSocket subscribers.
+// Failures are non-critical — WS clients will get updates on next poll.
+func (s *Store) NotifyPython(ipnsName string, sequence int64, cid string) {
+	notifyURL := fmt.Sprintf("%s/internal/ws-notify?name=%s&sequence=%d&cid=%s",
+		s.pythonURL, url.QueryEscape(ipnsName), sequence, url.QueryEscape(cid))
+	resp, err := s.notifyClient.Post(notifyURL, "", nil)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}

--- a/go-sidecar/websocket.go
+++ b/go-sidecar/websocket.go
@@ -11,55 +11,105 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const (
+	// MaxSubscriptionsPerConn limits how many IPNS names a single client
+	// can subscribe to, preventing memory exhaustion from malicious clients.
+	MaxSubscriptionsPerConn = 200
+
+	// MaxTotalConnections limits the total number of concurrent WebSocket
+	// connections the sidecar will accept.
+	MaxTotalConnections = 1000
+
+	// wsReadLimit caps the maximum size of a single WebSocket message.
+	wsReadLimit = 4096
+)
+
 var wsUpgrader = websocket.Upgrader{
-	CheckOrigin:     func(r *http.Request) bool { return true }, // CORS handled by nginx
+	// Origin check intentionally permissive: this is a public IPNS
+	// subscription service. CORS headers are added by nginx. Rate
+	// limiting and subscription caps prevent abuse.
+	CheckOrigin:     func(r *http.Request) bool { return true },
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 }
 
+// safeConn wraps a websocket.Conn with a write mutex to prevent
+// concurrent WriteMessage calls (gorilla/websocket is not safe for
+// concurrent writes).
+type safeConn struct {
+	conn *websocket.Conn
+	wmu  sync.Mutex
+	// Number of subscriptions this connection holds.
+	subCount int
+}
+
+func (sc *safeConn) writeJSON(data []byte) error {
+	sc.wmu.Lock()
+	defer sc.wmu.Unlock()
+	sc.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return sc.conn.WriteMessage(websocket.TextMessage, data)
+}
+
 // SubscriptionManager manages WebSocket subscriptions for IPNS updates.
-// Clients connect, subscribe to IPNS names, and receive push notifications.
 type SubscriptionManager struct {
 	mu   sync.RWMutex
-	subs map[string]map[*websocket.Conn]struct{} // ipnsName → set of conns
+	subs map[string]map[*safeConn]struct{} // ipnsName → set of conns
+
+	connMu    sync.Mutex
+	connCount int
 }
 
 func NewSubscriptionManager() *SubscriptionManager {
 	return &SubscriptionManager{
-		subs: make(map[string]map[*websocket.Conn]struct{}),
+		subs: make(map[string]map[*safeConn]struct{}),
 	}
 }
 
 // wsMessage is the JSON envelope for client↔server WebSocket messages.
 type wsMessage struct {
-	Action   string   `json:"action,omitempty"`
-	Type     string   `json:"type,omitempty"`
-	Names    []string `json:"names,omitempty"`
-	Name     string   `json:"name,omitempty"`
-	Sequence int64    `json:"sequence,omitempty"`
-	CID      string   `json:"cid,omitempty"`
-	Message  string   `json:"message,omitempty"`
-	// Timestamp is only set on outbound update messages.
-	Timestamp string `json:"timestamp,omitempty"`
+	Action    string   `json:"action,omitempty"`
+	Type      string   `json:"type,omitempty"`
+	Names     []string `json:"names,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Sequence  int64    `json:"sequence,omitempty"`
+	CID       string   `json:"cid,omitempty"`
+	Message   string   `json:"message,omitempty"`
+	Timestamp string   `json:"timestamp,omitempty"`
 }
 
-// ipnsNameRE is already defined in ipns.go — reuse for WS validation.
 var wsIPNSNameRE = regexp.MustCompile(`^(12D3KooW[a-zA-Z0-9]{44}|k[a-z2-7]{50,})$`)
 
 // HandleWebSocket upgrades an HTTP connection and manages subscriptions.
 func (sm *SubscriptionManager) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	conn, err := wsUpgrader.Upgrade(w, r, nil)
-	if err != nil {
-		log.Printf("ws: upgrade error: %v", err)
+	// Enforce global connection limit.
+	sm.connMu.Lock()
+	if sm.connCount >= MaxTotalConnections {
+		sm.connMu.Unlock()
+		http.Error(w, "Too many connections", http.StatusServiceUnavailable)
 		return
 	}
+	sm.connCount++
+	sm.connMu.Unlock()
+
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		sm.connMu.Lock()
+		sm.connCount--
+		sm.connMu.Unlock()
+		return
+	}
+
+	sc := &safeConn{conn: conn}
+	conn.SetReadLimit(wsReadLimit)
+
 	defer func() {
-		sm.removeAll(conn)
+		sm.removeAll(sc)
 		conn.Close()
+		sm.connMu.Lock()
+		sm.connCount--
+		sm.connMu.Unlock()
 	}()
 
-	// Set read deadline for idle timeout (client should send ping/subscribe
-	// periodically). Reset on every message received.
 	conn.SetReadDeadline(time.Now().Add(90 * time.Second))
 	conn.SetPongHandler(func(string) error {
 		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
@@ -82,7 +132,7 @@ func (sm *SubscriptionManager) HandleWebSocket(w http.ResponseWriter, r *http.Re
 
 		var msg wsMessage
 		if err := json.Unmarshal(msgBytes, &msg); err != nil {
-			sm.sendJSON(conn, wsMessage{Type: "error", Message: "Invalid JSON"})
+			sm.sendJSON(sc, wsMessage{Type: "error", Message: "Invalid JSON"})
 			continue
 		}
 
@@ -90,24 +140,27 @@ func (sm *SubscriptionManager) HandleWebSocket(w http.ResponseWriter, r *http.Re
 		case "subscribe":
 			var valid []string
 			for _, name := range msg.Names {
+				if sc.subCount >= MaxSubscriptionsPerConn {
+					break
+				}
 				if wsIPNSNameRE.MatchString(name) {
-					sm.addSub(name, conn)
+					sm.addSub(name, sc)
 					valid = append(valid, name)
 				}
 			}
-			sm.sendJSON(conn, wsMessage{Type: "subscribed", Names: valid})
+			sm.sendJSON(sc, wsMessage{Type: "subscribed", Names: valid})
 
 		case "unsubscribe":
 			for _, name := range msg.Names {
-				sm.removeSub(name, conn)
+				sm.removeSub(name, sc)
 			}
-			sm.sendJSON(conn, wsMessage{Type: "unsubscribed", Names: msg.Names})
+			sm.sendJSON(sc, wsMessage{Type: "unsubscribed", Names: msg.Names})
 
 		case "ping":
-			sm.sendJSON(conn, wsMessage{Type: "pong"})
+			sm.sendJSON(sc, wsMessage{Type: "pong"})
 
 		default:
-			sm.sendJSON(conn, wsMessage{Type: "error", Message: "Unknown action"})
+			sm.sendJSON(sc, wsMessage{Type: "error", Message: "Unknown action"})
 		}
 	}
 }
@@ -120,8 +173,7 @@ func (sm *SubscriptionManager) Notify(ipnsName string, sequence int64, cid strin
 		sm.mu.RUnlock()
 		return
 	}
-	// Copy the set under read-lock to avoid holding it during writes.
-	targets := make([]*websocket.Conn, 0, len(conns))
+	targets := make([]*safeConn, 0, len(conns))
 	for c := range conns {
 		targets = append(targets, c)
 	}
@@ -139,64 +191,58 @@ func (sm *SubscriptionManager) Notify(ipnsName string, sequence int64, cid strin
 		return
 	}
 
-	for _, c := range targets {
-		if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
-			// Connection broken — remove it.
-			sm.removeAll(c)
-			c.Close()
+	for _, sc := range targets {
+		if err := sc.writeJSON(data); err != nil {
+			sm.removeAll(sc)
+			sc.conn.Close()
 		}
 	}
 }
 
-// ConnectionCount returns the total number of active WebSocket connections.
-func (sm *SubscriptionManager) ConnectionCount() int {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	seen := make(map[*websocket.Conn]struct{})
-	for _, conns := range sm.subs {
-		for c := range conns {
-			seen[c] = struct{}{}
-		}
-	}
-	return len(seen)
-}
-
-func (sm *SubscriptionManager) addSub(ipnsName string, conn *websocket.Conn) {
+func (sm *SubscriptionManager) addSub(ipnsName string, sc *safeConn) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if sm.subs[ipnsName] == nil {
-		sm.subs[ipnsName] = make(map[*websocket.Conn]struct{})
+		sm.subs[ipnsName] = make(map[*safeConn]struct{})
 	}
-	sm.subs[ipnsName][conn] = struct{}{}
+	if _, exists := sm.subs[ipnsName][sc]; !exists {
+		sm.subs[ipnsName][sc] = struct{}{}
+		sc.subCount++
+	}
 }
 
-func (sm *SubscriptionManager) removeSub(ipnsName string, conn *websocket.Conn) {
+func (sm *SubscriptionManager) removeSub(ipnsName string, sc *safeConn) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if conns, ok := sm.subs[ipnsName]; ok {
-		delete(conns, conn)
-		if len(conns) == 0 {
-			delete(sm.subs, ipnsName)
+		if _, exists := conns[sc]; exists {
+			delete(conns, sc)
+			sc.subCount--
+			if len(conns) == 0 {
+				delete(sm.subs, ipnsName)
+			}
 		}
 	}
 }
 
-func (sm *SubscriptionManager) removeAll(conn *websocket.Conn) {
+func (sm *SubscriptionManager) removeAll(sc *safeConn) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	for name, conns := range sm.subs {
-		delete(conns, conn)
-		if len(conns) == 0 {
-			delete(sm.subs, name)
+		if _, exists := conns[sc]; exists {
+			delete(conns, sc)
+			sc.subCount--
+			if len(conns) == 0 {
+				delete(sm.subs, name)
+			}
 		}
 	}
 }
 
-func (sm *SubscriptionManager) sendJSON(conn *websocket.Conn, msg wsMessage) {
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+func (sm *SubscriptionManager) sendJSON(sc *safeConn, msg wsMessage) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return
 	}
-	conn.WriteMessage(websocket.TextMessage, data)
+	sc.writeJSON(data)
 }

--- a/go-sidecar/websocket.go
+++ b/go-sidecar/websocket.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin:     func(r *http.Request) bool { return true }, // CORS handled by nginx
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+// SubscriptionManager manages WebSocket subscriptions for IPNS updates.
+// Clients connect, subscribe to IPNS names, and receive push notifications.
+type SubscriptionManager struct {
+	mu   sync.RWMutex
+	subs map[string]map[*websocket.Conn]struct{} // ipnsName → set of conns
+}
+
+func NewSubscriptionManager() *SubscriptionManager {
+	return &SubscriptionManager{
+		subs: make(map[string]map[*websocket.Conn]struct{}),
+	}
+}
+
+// wsMessage is the JSON envelope for client↔server WebSocket messages.
+type wsMessage struct {
+	Action   string   `json:"action,omitempty"`
+	Type     string   `json:"type,omitempty"`
+	Names    []string `json:"names,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Sequence int64    `json:"sequence,omitempty"`
+	CID      string   `json:"cid,omitempty"`
+	Message  string   `json:"message,omitempty"`
+	// Timestamp is only set on outbound update messages.
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// ipnsNameRE is already defined in ipns.go — reuse for WS validation.
+var wsIPNSNameRE = regexp.MustCompile(`^(12D3KooW[a-zA-Z0-9]{44}|k[a-z2-7]{50,})$`)
+
+// HandleWebSocket upgrades an HTTP connection and manages subscriptions.
+func (sm *SubscriptionManager) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("ws: upgrade error: %v", err)
+		return
+	}
+	defer func() {
+		sm.removeAll(conn)
+		conn.Close()
+	}()
+
+	// Set read deadline for idle timeout (client should send ping/subscribe
+	// periodically). Reset on every message received.
+	conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+		return nil
+	})
+
+	for {
+		_, msgBytes, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseGoingAway,
+				websocket.CloseNormalClosure,
+				websocket.CloseNoStatusReceived) {
+				log.Printf("ws: read error: %v", err)
+			}
+			break
+		}
+
+		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
+
+		var msg wsMessage
+		if err := json.Unmarshal(msgBytes, &msg); err != nil {
+			sm.sendJSON(conn, wsMessage{Type: "error", Message: "Invalid JSON"})
+			continue
+		}
+
+		switch msg.Action {
+		case "subscribe":
+			var valid []string
+			for _, name := range msg.Names {
+				if wsIPNSNameRE.MatchString(name) {
+					sm.addSub(name, conn)
+					valid = append(valid, name)
+				}
+			}
+			sm.sendJSON(conn, wsMessage{Type: "subscribed", Names: valid})
+
+		case "unsubscribe":
+			for _, name := range msg.Names {
+				sm.removeSub(name, conn)
+			}
+			sm.sendJSON(conn, wsMessage{Type: "unsubscribed", Names: msg.Names})
+
+		case "ping":
+			sm.sendJSON(conn, wsMessage{Type: "pong"})
+
+		default:
+			sm.sendJSON(conn, wsMessage{Type: "error", Message: "Unknown action"})
+		}
+	}
+}
+
+// Notify pushes an IPNS update to all subscribers of the given name.
+func (sm *SubscriptionManager) Notify(ipnsName string, sequence int64, cid string) {
+	sm.mu.RLock()
+	conns, ok := sm.subs[ipnsName]
+	if !ok || len(conns) == 0 {
+		sm.mu.RUnlock()
+		return
+	}
+	// Copy the set under read-lock to avoid holding it during writes.
+	targets := make([]*websocket.Conn, 0, len(conns))
+	for c := range conns {
+		targets = append(targets, c)
+	}
+	sm.mu.RUnlock()
+
+	msg := wsMessage{
+		Type:      "update",
+		Name:      ipnsName,
+		Sequence:  sequence,
+		CID:       cid,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+
+	for _, c := range targets {
+		if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
+			// Connection broken — remove it.
+			sm.removeAll(c)
+			c.Close()
+		}
+	}
+}
+
+// ConnectionCount returns the total number of active WebSocket connections.
+func (sm *SubscriptionManager) ConnectionCount() int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	seen := make(map[*websocket.Conn]struct{})
+	for _, conns := range sm.subs {
+		for c := range conns {
+			seen[c] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func (sm *SubscriptionManager) addSub(ipnsName string, conn *websocket.Conn) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.subs[ipnsName] == nil {
+		sm.subs[ipnsName] = make(map[*websocket.Conn]struct{})
+	}
+	sm.subs[ipnsName][conn] = struct{}{}
+}
+
+func (sm *SubscriptionManager) removeSub(ipnsName string, conn *websocket.Conn) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if conns, ok := sm.subs[ipnsName]; ok {
+		delete(conns, conn)
+		if len(conns) == 0 {
+			delete(sm.subs, ipnsName)
+		}
+	}
+}
+
+func (sm *SubscriptionManager) removeAll(conn *websocket.Conn) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	for name, conns := range sm.subs {
+		delete(conns, conn)
+		if len(conns) == 0 {
+			delete(sm.subs, name)
+		}
+	}
+}
+
+func (sm *SubscriptionManager) sendJSON(conn *websocket.Conn, msg wsMessage) {
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	conn.WriteMessage(websocket.TextMessage, data)
+}

--- a/nostr-pinner/nostr_pinner.py
+++ b/nostr-pinner/nostr_pinner.py
@@ -452,6 +452,22 @@ def build_routing_response_json(record_bytes: bytes) -> str:
     return '{"Extra":"' + base64.b64encode(record_bytes).decode('ascii') + '","Type":5}'
 
 
+async def notify_go_sidecar_ws(ipns_name: str, sequence: int, cid: str | None):
+    """Notify Go sidecar to push WebSocket update to subscribers (issue #17).
+
+    Go sidecar owns all WebSocket connections. After Python stores a record,
+    POST to Go's /internal/ws-notify so Go can push to connected clients.
+    Fire-and-forget: failures are non-critical.
+    """
+    try:
+        go_url = os.getenv("GO_SIDECAR_URL", "http://127.0.0.1:9082")
+        url = f"{go_url}/internal/ws-notify?name={ipns_name}&sequence={sequence}&cid={cid or ''}"
+        response = await get_shared_http_client().post(url)
+        await response.aclose()
+    except Exception:
+        pass  # Non-critical: WS clients will get update on next poll
+
+
 def is_valid_cid(cid: str) -> bool:
     """Validate CID format (CIDv0 or CIDv1)."""
     if not cid:
@@ -1771,8 +1787,8 @@ class DhtSyncWorker:
                 )
                 await self.ipns_store.store_record(ipns_name, record_bytes)
 
-                # Notify WebSocket subscribers of update
-                await self.subscription_manager.notify(
+                # Notify Go sidecar to push WebSocket update
+                await notify_go_sidecar_ws(
                     ipns_name, kubo_sequence, cid
                 )
             else:
@@ -2119,40 +2135,19 @@ class IpnsInterceptServer:
         self.app.router.add_get('/health', self._handle_health)
         self.app.router.add_get('/metrics', self._handle_metrics)
         self.app.router.add_post('/reannounce', self._handle_reannounce)
-        # Fast-path serving endpoints
+        # Fast-path serving endpoints (routing-get and ws/ipns now handled by Go sidecar)
         self.app.router.add_get('/routing-get', self._handle_routing_get)
-        self.app.router.add_post('/routing-get', self._handle_routing_get)  # Support POST like kubo
+        self.app.router.add_post('/routing-get', self._handle_routing_get)  # Fallback if Go is down
         self.app.router.add_get('/pin-status', self._handle_pin_status)
-        # WebSocket endpoint for IPNS subscriptions
-        self.app.router.add_get('/ws/ipns', self.subscription_manager.handle_websocket)
-        # Go sidecar → Python WS notification callback (issue #17)
-        self.app.router.add_post('/internal/ws-notify', self._handle_ws_notify)
         # Instant-pin write-through cache endpoints (issue #6)
         self.app.router.add_post('/sidecar/submit', self._handle_sidecar_submit)
         self.app.router.add_get('/sidecar/blob', self._handle_sidecar_blob)
         self.app.router.add_post('/sidecar/blob', self._handle_sidecar_blob)
         self.app.router.add_get('/sidecar/cache-stats', self._handle_sidecar_cache_stats)
 
-    async def _handle_ws_notify(self, request: web.Request) -> web.Response:
-        """
-        Handle WebSocket notification callback from Go sidecar (issue #17).
-
-        When the Go sidecar refreshes a stale IPNS record from the DHT and
-        finds a newer sequence, it POSTs here so we can push the update to
-        connected WebSocket subscribers.
-        """
-        try:
-            ipns_name = request.query.get('name', '')
-            sequence = int(request.query.get('sequence', '0'))
-            cid = request.query.get('cid', '')
-
-            if ipns_name and sequence > 0:
-                await self.subscription_manager.notify(ipns_name, sequence, cid or None)
-
-            return web.Response(status=204)
-        except Exception as e:
-            logger.debug(f"ws-notify error: {e}")
-            return web.Response(status=204)  # Non-critical, always return OK
+    async def _notify_go_sidecar_ws(self, ipns_name: str, sequence: int, cid: str | None):
+        """Delegate to module-level function."""
+        await notify_go_sidecar_ws(ipns_name, sequence, cid)
 
     async def _handle_ipns_intercept(self, request: web.Request) -> web.Response:
         """
@@ -2233,6 +2228,9 @@ class IpnsInterceptServer:
                 stored = await self.ipns_store.store_record(ipns_name, record_bytes)
 
                 if stored:
+                    # Notify Go sidecar to push WebSocket update
+                    sequence, cid = parse_ipns_record(record_bytes)
+                    await self._notify_go_sidecar_ws(ipns_name, sequence, cid)
                     # Success - log and return OK
                     await log_security_audit(
                         self.db, "ipns_intercept_accepted", client_ip, ipns_name,
@@ -2417,7 +2415,7 @@ class IpnsInterceptServer:
                     await self.ipns_store.store_record(ipns_name, record_bytes)
 
                     # Notify WebSocket subscribers
-                    await self.subscription_manager.notify(ipns_name, sequence, cid)
+                    await notify_go_sidecar_ws(ipns_name, sequence, cid)
 
                     # Return the pre-serialized response (avoid json.dumps)
                     response_json = build_routing_response_json(record_bytes)
@@ -2472,8 +2470,8 @@ class IpnsInterceptServer:
             stored = await self.ipns_store.store_record(ipns_name, record_bytes)
 
             if stored:
-                # Push to all subscribed clients via WebSocket
-                await self.subscription_manager.notify(ipns_name, sequence, cid)
+                # Push to all subscribed clients via Go sidecar WebSocket
+                await notify_go_sidecar_ws(ipns_name, sequence, cid)
                 logger.info(f"Background refresh complete: {ipns_name[:16]}... seq={sequence}")
 
         except asyncio.TimeoutError:

--- a/nostr-pinner/nostr_pinner.py
+++ b/nostr-pinner/nostr_pinner.py
@@ -460,9 +460,10 @@ async def notify_go_sidecar_ws(ipns_name: str, sequence: int, cid: str | None):
     Fire-and-forget: failures are non-critical.
     """
     try:
+        from urllib.parse import urlencode
         go_url = os.getenv("GO_SIDECAR_URL", "http://127.0.0.1:9082")
-        url = f"{go_url}/internal/ws-notify?name={ipns_name}&sequence={sequence}&cid={cid or ''}"
-        response = await get_shared_http_client().post(url)
+        params = urlencode({"name": ipns_name, "sequence": sequence, "cid": cid or ""})
+        response = await get_shared_http_client().post(f"{go_url}/internal/ws-notify?{params}")
         await response.aclose()
     except Exception:
         pass  # Non-critical: WS clients will get update on next poll

--- a/nostr-pinner/nostr_pinner.py
+++ b/nostr-pinner/nostr_pinner.py
@@ -2125,11 +2125,34 @@ class IpnsInterceptServer:
         self.app.router.add_get('/pin-status', self._handle_pin_status)
         # WebSocket endpoint for IPNS subscriptions
         self.app.router.add_get('/ws/ipns', self.subscription_manager.handle_websocket)
+        # Go sidecar → Python WS notification callback (issue #17)
+        self.app.router.add_post('/internal/ws-notify', self._handle_ws_notify)
         # Instant-pin write-through cache endpoints (issue #6)
         self.app.router.add_post('/sidecar/submit', self._handle_sidecar_submit)
         self.app.router.add_get('/sidecar/blob', self._handle_sidecar_blob)
         self.app.router.add_post('/sidecar/blob', self._handle_sidecar_blob)
         self.app.router.add_get('/sidecar/cache-stats', self._handle_sidecar_cache_stats)
+
+    async def _handle_ws_notify(self, request: web.Request) -> web.Response:
+        """
+        Handle WebSocket notification callback from Go sidecar (issue #17).
+
+        When the Go sidecar refreshes a stale IPNS record from the DHT and
+        finds a newer sequence, it POSTs here so we can push the update to
+        connected WebSocket subscribers.
+        """
+        try:
+            ipns_name = request.query.get('name', '')
+            sequence = int(request.query.get('sequence', '0'))
+            cid = request.query.get('cid', '')
+
+            if ipns_name and sequence > 0:
+                await self.subscription_manager.notify(ipns_name, sequence, cid or None)
+
+            return web.Response(status=204)
+        except Exception as e:
+            logger.debug(f"ws-notify error: {e}")
+            return web.Response(status=204)  # Non-critical, always return OK
 
     async def _handle_ipns_intercept(self, request: web.Request) -> web.Response:
         """


### PR DESCRIPTION
## Summary

- Add a Go sidecar binary that handles the high-throughput IPNS read path (`/routing-get`), background DHT refresh, and WebSocket subscriptions (`/ws/ipns`), eliminating CPython pymalloc arena fragmentation that caused ~250 MB/min memory growth
- Python pinner retains write-path responsibilities: Nostr relay subscriptions, ipns-intercept with chain validation, pin management, and sidecar cache
- Both processes share the SQLite database via WAL mode

Closes the Go sidecar portion of #17. Follow-up work for remaining Python leak (~160 MB/min from chain validation) tracked in #19.

## Architecture

```
                          ┌──────────────────────────────────┐
                          │      Go sidecar (:9082)          │
Browser ──nginx───────────┤  /routing-get  (SQLite read)     │
                          │  DHT refresh   (kubo HTTP)       │
                          │  /ws/ipns      (WebSocket push)  │
                          │  /internal/ws-notify (from Python)│
                          └──────────┬───────────────────────┘
                                     │ SQLite WAL (shared)
                          ┌──────────┴───────────────────────┐
                          │      Python nostr_pinner (:9081)  │
                          │  /ipns-intercept (chain validated) │
                          │  Nostr relay subscriptions        │
                          │  /sidecar/* (instant-pin cache)   │
                          │  /pin-status, /metrics, /health   │
                          └──────────────────────────────────┘
```

## Changes

### New: `go-sidecar/` (7 MB compiled binary)
- **`main.go`** — HTTP server, config from env vars, signal handling
- **`handlers.go`** — `/routing-get` (SQLite read → DHT fallback → async refresh), `/internal/ws-notify`, `/health`
- **`refresh.go`** — Background DHT refresh worker with bounded concurrency
- **`websocket.go`** — WebSocket subscription manager (subscribe/unsubscribe/ping/push)
- **`store.go`** — Shared SQLite write operations, WS notification dispatch
- **`ipns.go`** — IPNS protobuf parser, `Extra` field extraction, response builder

### Modified
- **`Dockerfile`** — Multi-stage build with `golang:1.22-bookworm` for Go sidecar
- **`config/supervisord.conf`** — Added `go-sidecar` process (priority 350)
- **`config/nginx.conf.template`** — Added `upstream go_sidecar` on port 9082; `/api/v0/routing/get` and `/ws/ipns` route to Go instead of Python
- **`nostr-pinner/nostr_pinner.py`** — Added `notify_go_sidecar_ws()` for Python→Go WS push after ipns-intercept writes; all `subscription_manager.notify` calls redirect to Go

## Production Results

Deployed and measured on production (99k+ IPNS records, ~43 req/sec):

| Component | RSS | Growth | Notes |
|-----------|-----|--------|-------|
| **Go sidecar** | **27 MB** | **flat** | routing-get, DHT refresh, WebSocket |
| Python pinner | ~160 MB/min | leaking | chain validation HTTP calls (tracked in #19) |

| Metric | Before | After |
|--------|--------|-------|
| Python memory growth | ~250 MB/min | ~160 MB/min (36% reduction) |
| Self-restart cycle | ~15 min | ~25 min |
| `/routing-get` latency | 5-20ms (Python) | <1ms (Go + SQLite) |
| WebSocket handler | Python (300 conn/min churn) | Go (stable goroutines) |
| DHT refresh | Python (pymalloc fragmentation) | Go (27 MB flat) |

## Test Plan

- [x] Go sidecar compiles in Docker multi-stage build
- [x] All supervisord processes start and stay RUNNING
- [x] `/routing-get` returns correct JSON with `X-IPNS-Source: go-sidecar`
- [x] nginx routing-cache returns `X-Routing-Cache: HIT` on repeated lookups
- [x] Background DHT refresh updates stale records (verified via logs)
- [x] WebSocket connections no longer reach Python (verified: 0 "New WebSocket connection" logs)
- [x] Go sidecar memory stays flat at ~27 MB over 10+ minutes
- [x] Python→Go ws-notify callback works for ipns-intercept writes
- [x] Container health check passes